### PR TITLE
🐞 BugFix - BCryptPasswordEncoder.matches를 사용하지 않던 버그 수정

### DIFF
--- a/http/auth/AuthControllerHttpRequest.http
+++ b/http/auth/AuthControllerHttpRequest.http
@@ -46,15 +46,15 @@ Content-Type: application/json
 
 ### 2.1.2 유저 회원가입
 // @no-log
-POST {{host_url}}/v1/users/auth/sign-up
+POST {{host_url}}/v1/auth/users/sign-up-default
 Content-Type: application/json
 
 {
-    "name": "{{auth.API_2_2.name}}",
-    "serial_id": "{{auth.API_2_2.serial_id}}",
-    "password": "{{auth.API_2_2.password}}",
-    "phone_number": "{{auth.API_2_2.phone_number}}",
-    "marketing_allowed": {{auth.API_2_2.marketing_allowed}}
+    "name": "{{auth.API_2_1_2.name}}",
+    "serial_id": "{{auth.API_2_1_2.serial_id}}",
+    "password": "{{auth.API_2_1_2.password}}",
+    "phone_number": "{{auth.API_2_1_2.phone_number}}",
+    "marketing_allowed": {{auth.API_2_1_2.marketing_allowed}}
 }
 
 ### 2.1.5 관리자 회원가입
@@ -69,8 +69,8 @@ Content-Type: application/json
 
 ### 2.3.1 휴대폰 인증번호 검증
 // @no-log
-@authentication_code = "995659"
-PATCH {{host_url}}/v1/users/auth/authentication-code
+@authentication_code = "329523"
+PATCH {{host_url}}/v1/auth/authentication-code
 Content-Type: application/json
 
 {

--- a/src/main/java/com/tookscan/tookscan/security/application/service/ChangePasswordService.java
+++ b/src/main/java/com/tookscan/tookscan/security/application/service/ChangePasswordService.java
@@ -1,5 +1,7 @@
 package com.tookscan.tookscan.security.application.service;
 
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.security.application.dto.request.ChangePasswordRequestDto;
 import com.tookscan.tookscan.security.application.usecase.ChangePasswordUseCase;
 import com.tookscan.tookscan.security.domain.mysql.Account;
@@ -29,7 +31,9 @@ public class ChangePasswordService implements ChangePasswordUseCase {
         Account account = accountRepository.findByIdOrElseThrow(accountId);
 
         // 이전 비밀번호 일치 여부 확인
-        accountService.checkPassword(account, requestDto.oldPassword());
+        if (!bCryptPasswordEncoder.matches(requestDto.oldPassword(), account.getPassword())) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT);
+        }
 
         // 비밀번호 변경
         accountService.changePassword(account, bCryptPasswordEncoder.encode(requestDto.newPassword()));


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #149 

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [ ] Docker Container 환경으로 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). (필수)
- [ ] Feature의 경우, API 문서 업데이트를 완료했습니다. (선택)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 이전 비밀번호 일치 여부 확인에서 BCryptPasswordEncoder.matches를 사용하지 않던 버그 수정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 등록 및 인증 코드 확인을 위한 API 엔드포인트와 요청 데이터 구조가 업데이트되었습니다.
- **버그 수정**
	- 비밀번호 변경 시 기존 검증 방식을 개선하여, 암호화 기반의 보다 정확한 오류 처리가 구현되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->