### PR TITLE
🔨 Fix - pdf 이메일 전송 cloudfront url 전송 jar 파일 내부에서 파일 읽도록 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
@@ -12,6 +12,7 @@ import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Document;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -172,7 +173,8 @@ public class S3Util {
                 throw new CommonException(ErrorCode.NOT_FOUND_PDF_FILE);
             }
 
-            File privateKey = new ClassPathResource(privateKeyPath).getFile();
+            // jar 내부의 private key 파일을 임시 파일로 복사
+            File privateKey = extractResourceToTempFile(privateKeyPath);
 
             return CloudFrontUrlSigner.getSignedURLWithCannedPolicy(
                     SignerUtils.Protocol.https,
@@ -185,5 +187,20 @@ public class S3Util {
         } catch (InvalidKeySpecException | IOException e) {
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
         }
+    }
+
+    private File extractResourceToTempFile(String resourcePath) throws IOException {
+        ClassPathResource resource = new ClassPathResource(resourcePath);
+        File tempFile = File.createTempFile("aws_ex_private_key", ".pem");
+        try (InputStream in = resource.getInputStream();
+             FileOutputStream out = new FileOutputStream(tempFile)) {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        }
+        tempFile.deleteOnExit();
+        return tempFile;
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #386 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- pdf 이메일 전송 cloudfront url 전송 jar 파일 내부에서 파일 읽도록 수정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 서명 URL 생성 기능과 관련된 민감 데이터 처리를 위한 임시 파일 관리 방식을 개선하여 보안과 자원 정리 측면에서 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->