### PR TITLE
🔨 Fix - Document의 name length 제한 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/domain/Document.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Document.java
@@ -30,7 +30,7 @@ public class Document extends BaseEntity {
     /* -------------------------------------------- */
     /* Information Column ------------------------- */
     /* -------------------------------------------- */
-    @Column(name = "name", length = 30, nullable = false)
+    @Column(name = "name", length = 100, nullable = false)
     private String name;
 
     @Column(name = "page_count", nullable = false)


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #413 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- Document의 name length 제한 수정
길이제한이 30으로 되어있어서, 수정 시 너무 긴 길이의 책 제목에 대해 SQL Error가 발생했다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 문서 이름 입력 필드의 최대 글자 수가 30자에서 100자로 확장되었습니다.  
  - 이를 통해 사용자는 보다 긴 문서 이름을 입력할 수 있으며, 문서 식별에 필요한 정보를 더욱 명확하게 표현할 수 있게 되었습니다.  
  - 이번 업데이트는 입력 제약을 완화하여 더 폭넓은 데이터 입력 환경을 제공하고 사용자 편의성을 증대시키는 효과를 기대할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->