### PR TITLE
🔨 Fix - AddressRequestDto 유효성 검증 버그 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/account/presentation/dto/request/UpdateAdminUserRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/account/presentation/dto/request/UpdateAdminUserRequestDto.java
@@ -2,6 +2,7 @@ package com.tookscan.tookscan.account.presentation.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tookscan.tookscan.address.dto.request.AddressRequestDto;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -24,6 +25,7 @@ public record UpdateAdminUserRequestDto(
         String email,
 
         @JsonProperty("address")
+        @Valid
         AddressRequestDto address,
 
         @JsonProperty("memo")

--- a/src/main/java/com/tookscan/tookscan/account/presentation/dto/request/UpdateUserUserRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/account/presentation/dto/request/UpdateUserUserRequestDto.java
@@ -3,6 +3,7 @@ package com.tookscan.tookscan.account.presentation.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tookscan.tookscan.address.dto.request.AddressRequestDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -24,6 +25,7 @@ public record UpdateUserUserRequestDto(
 
         @JsonProperty("address")
         @Schema(description = "주소")
+        @Valid
         AddressRequestDto address,
 
         @JsonProperty("is_receive_sms")

--- a/src/main/java/com/tookscan/tookscan/address/dto/request/AddressRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/address/dto/request/AddressRequestDto.java
@@ -83,6 +83,7 @@ public record AddressRequestDto(
                         .region3DepthName(region3DepthName)
                         .region4DepthName(region4DepthName)
                         .addressDetail(addressDetail)
+                        .zoneCode(zoneCode)
                         .latitude(latitude)
                         .longitude(longitude)
                         .build();

--- a/src/main/java/com/tookscan/tookscan/address/dto/response/AddressResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/address/dto/response/AddressResponseDto.java
@@ -87,6 +87,7 @@ public class AddressResponseDto extends SelfValidating<AddressResponseDto> {
                 .region3DepthName(address.getRegion3DepthName())
                 .region4DepthName(address.getRegion4DepthName() != null ? address.getRegion4DepthName() : null)
                 .addressDetail(address.getAddressDetail())
+                .zoneCode(address.getZoneCode())
                 .longitude(address.getLongitude())
                 .latitude(address.getLatitude())
                 .build();

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/CreateUserOrderRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/CreateUserOrderRequestDto.java
@@ -85,6 +85,7 @@ public record CreateUserOrderRequestDto(
 
             @NotNull(message = "주소를 입력해주세요.")
             @JsonProperty("address")
+            @Valid
             AddressRequestDto address
     ) {
     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/UpdateAdminOrderDeliveryRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/UpdateAdminOrderDeliveryRequestDto.java
@@ -2,6 +2,7 @@ package com.tookscan.tookscan.order.presentation.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tookscan.tookscan.address.dto.request.AddressRequestDto;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -22,6 +23,7 @@ public record UpdateAdminOrderDeliveryRequestDto(
 
         @JsonProperty("address")
         @NotNull(message = "주소를 입력해주세요.")
+        @Valid
         AddressRequestDto address,
 
         @JsonProperty("request")


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #435 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- AddressRequestDto 유효성 검증을 진행하도록 수정하였습니다.
- AddressResponseDto 에서 fromEntity에 zoneCode를 추가하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 주소 정보가 포함된 요청에서 주소 필드의 유효성 검사가 올바르게 동작하도록 개선되었습니다.
	- 주문 및 사용자 정보 업데이트 시 주소의 zoneCode(우편번호) 정보가 누락되지 않고 정상적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->