### PR TITLE
🔨 Fix - 회원가입 시 곧바로 JWT 발급하도록 변경

### DIFF
--- a/src/main/java/com/tookscan/tookscan/account/repository/UserRepository.java
+++ b/src/main/java/com/tookscan/tookscan/account/repository/UserRepository.java
@@ -14,7 +14,7 @@ public interface UserRepository {
 
     List<User> findByIds(List<UUID> userIds);
 
-    void save(User user);
+    User save(User user);
 
     User findByPhoneNumberAndNameOrElseThrow(String phoneNumber, String name);
 

--- a/src/main/java/com/tookscan/tookscan/account/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/account/repository/impl/UserRepositoryImpl.java
@@ -40,8 +40,8 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public void save(User user) {
-        userJpaRepository.save(user);
+    public User save(User user) {
+        return userJpaRepository.save(user);
     }
 
     @Override

--- a/src/main/java/com/tookscan/tookscan/security/application/service/SignUpDefaultService.java
+++ b/src/main/java/com/tookscan/tookscan/security/application/service/SignUpDefaultService.java
@@ -3,6 +3,8 @@ package com.tookscan.tookscan.security.application.service;
 import com.tookscan.tookscan.account.domain.User;
 import com.tookscan.tookscan.account.domain.service.UserService;
 import com.tookscan.tookscan.account.repository.UserRepository;
+import com.tookscan.tookscan.core.utility.JsonWebTokenUtil;
+import com.tookscan.tookscan.security.application.dto.DefaultJsonWebTokenDto;
 import com.tookscan.tookscan.security.presentation.dto.request.SignUpDefaultRequestDto;
 import com.tookscan.tookscan.security.application.usecase.SignUpDefaultUseCase;
 import com.tookscan.tookscan.security.domain.redis.AuthenticationCode;
@@ -29,10 +31,11 @@ public class SignUpDefaultService implements SignUpDefaultUseCase {
     private final UserService userService;
 
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JsonWebTokenUtil jsonWebTokenUtil;
 
     @Override
     @Transactional
-    public void execute(SignUpDefaultRequestDto requestDto) {
+    public DefaultJsonWebTokenDto execute(SignUpDefaultRequestDto requestDto) {
 
         // 중복된 아이디인지 확인
         accountRepository.existsBySerialIdAndProviderThenThrow(requestDto.serialId(), ESecurityProvider.DEFAULT);
@@ -57,12 +60,15 @@ public class SignUpDefaultService implements SignUpDefaultUseCase {
                 requestDto.isReceiveEmail(),
                 requestDto.isReceiveSms()
         );
-        userRepository.save(user);
+        User savedUser = userRepository.save(user);
 
         // 인증번호 삭제
         authenticationCodeRepository.deleteById(requestDto.phoneNumber());
 
         // 인증번호 발급 이력 삭제
         authenticationCodeHistoryRepository.deleteById(requestDto.phoneNumber());
+
+        // JWT 발급
+        return jsonWebTokenUtil.generateDefaultJsonWebTokens(savedUser.getId(), savedUser.getRole());
     }
 }

--- a/src/main/java/com/tookscan/tookscan/security/application/service/SignUpOauthService.java
+++ b/src/main/java/com/tookscan/tookscan/security/application/service/SignUpOauthService.java
@@ -5,20 +5,22 @@ import com.tookscan.tookscan.account.domain.service.UserService;
 import com.tookscan.tookscan.account.repository.UserRepository;
 import com.tookscan.tookscan.core.constant.Constants;
 import com.tookscan.tookscan.core.utility.JsonWebTokenUtil;
-import com.tookscan.tookscan.security.presentation.dto.request.SignUpOauthRequestDto;
+import com.tookscan.tookscan.security.application.dto.DefaultJsonWebTokenDto;
 import com.tookscan.tookscan.security.application.usecase.SignUpOauthUseCase;
 import com.tookscan.tookscan.security.domain.redis.AuthenticationCode;
 import com.tookscan.tookscan.security.domain.service.AuthenticationCodeService;
 import com.tookscan.tookscan.security.domain.type.ESecurityProvider;
+import com.tookscan.tookscan.security.presentation.dto.request.SignUpOauthRequestDto;
 import com.tookscan.tookscan.security.repository.AccountRepository;
 import com.tookscan.tookscan.security.repository.AuthenticationCodeHistoryRepository;
 import com.tookscan.tookscan.security.repository.AuthenticationCodeRepository;
 import io.jsonwebtoken.Claims;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -33,12 +35,11 @@ public class SignUpOauthService implements SignUpOauthUseCase {
     private final UserService userService;
 
     private final JsonWebTokenUtil jsonWebTokenUtil;
-
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Override
     @Transactional
-    public void execute(String temporaryToken, SignUpOauthRequestDto requestDto) {
+    public DefaultJsonWebTokenDto execute(String temporaryToken, SignUpOauthRequestDto requestDto) {
 
         // temporary Token 파싱
         Claims claims = jsonWebTokenUtil.validateToken(temporaryToken);
@@ -71,12 +72,15 @@ public class SignUpOauthService implements SignUpOauthUseCase {
                 requestDto.isReceiveEmail(),
                 requestDto.isReceiveSms()
         );
-        userRepository.save(user);
+        User savedUser = userRepository.save(user);
 
         // 인증번호 삭제
         authenticationCodeRepository.deleteById(requestDto.phoneNumber());
 
         // 인증번호 발급 이력 삭제
         authenticationCodeHistoryRepository.deleteById(requestDto.phoneNumber());
+
+        // JWT 발급
+        return jsonWebTokenUtil.generateDefaultJsonWebTokens(savedUser.getId(), savedUser.getRole());
     }
 }

--- a/src/main/java/com/tookscan/tookscan/security/application/usecase/SignUpDefaultUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/security/application/usecase/SignUpDefaultUseCase.java
@@ -1,6 +1,7 @@
 package com.tookscan.tookscan.security.application.usecase;
 
 import com.tookscan.tookscan.core.annotation.bean.UseCase;
+import com.tookscan.tookscan.security.application.dto.DefaultJsonWebTokenDto;
 import com.tookscan.tookscan.security.presentation.dto.request.SignUpDefaultRequestDto;
 
 @UseCase
@@ -10,5 +11,5 @@ public interface SignUpDefaultUseCase {
      * @param requestDto 점주 회원가입 요청 DTO With Token
      * @return TemporaryJsonWebTokenDto
      */
-     void execute(SignUpDefaultRequestDto requestDto);
+     DefaultJsonWebTokenDto execute(SignUpDefaultRequestDto requestDto);
 }

--- a/src/main/java/com/tookscan/tookscan/security/application/usecase/SignUpOauthUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/security/application/usecase/SignUpOauthUseCase.java
@@ -1,6 +1,7 @@
 package com.tookscan.tookscan.security.application.usecase;
 
 import com.tookscan.tookscan.core.annotation.bean.UseCase;
+import com.tookscan.tookscan.security.application.dto.DefaultJsonWebTokenDto;
 import com.tookscan.tookscan.security.presentation.dto.request.SignUpOauthRequestDto;
 
 @UseCase
@@ -10,5 +11,5 @@ public interface SignUpOauthUseCase {
      * @param temporaryToken 임시 토큰
      * @param requestDto 소셜 로그인 회원가입 요청 DTO
      */
-    void execute(String temporaryToken, SignUpOauthRequestDto requestDto);
+    DefaultJsonWebTokenDto execute(String temporaryToken, SignUpOauthRequestDto requestDto);
 }

--- a/src/main/java/com/tookscan/tookscan/security/presentation/controller/AuthController.java
+++ b/src/main/java/com/tookscan/tookscan/security/presentation/controller/AuthController.java
@@ -7,7 +7,6 @@ import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.core.utility.HeaderUtil;
 import com.tookscan.tookscan.security.application.dto.DefaultJsonWebTokenDto;
-import com.tookscan.tookscan.security.application.usecase.AdminSignUpDefaultUseCase;
 import com.tookscan.tookscan.security.application.usecase.ChangePasswordUseCase;
 import com.tookscan.tookscan.security.application.usecase.DeleteAccountUseCase;
 import com.tookscan.tookscan.security.application.usecase.IssueAuthenticationCodeUseCase;
@@ -57,7 +56,6 @@ public class AuthController {
     private final ReissueJsonWebTokenUseCase reissueJsonWebTokenUseCase;
     private final IssueAuthenticationCodeUseCase issueAuthenticationCodeUseCase;
     private final SignUpDefaultUseCase signUpDefaultUseCase;
-    private final AdminSignUpDefaultUseCase adminSignUpDefaultUseCase;
     private final SignUpOauthUseCase signUpOauthUseCase;
     private final ReadSerialIdAndProviderUseCase readSerialIdAndProviderUseCase;
     private final ValidateIdUseCase validateIdUseCase;
@@ -93,11 +91,10 @@ public class AuthController {
      * 2.1.2 유저 회원가입
      */
     @PostMapping("/users/sign-up-default")
-    public ResponseDto<Void> signUpDefault(
+    public ResponseDto<DefaultJsonWebTokenDto> signUpDefault(
             @Valid @RequestBody SignUpDefaultRequestDto requestDto
     ) {
-        signUpDefaultUseCase.execute(requestDto);
-        return ResponseDto.created(null);
+        return ResponseDto.created(signUpDefaultUseCase.execute(requestDto));
     }
 
     /**
@@ -118,14 +115,13 @@ public class AuthController {
      * 2.1.3 소셜로그인 유저 회원가입
      */
     @PostMapping("/users/sign-up-oauth")
-    public ResponseDto<Void> signUpOauth(
+    public ResponseDto<DefaultJsonWebTokenDto> signUpOauth(
             @Valid @RequestBody SignUpOauthRequestDto requestDto,
             HttpServletRequest request
     ) {
         String temporaryToken = HeaderUtil.refineHeader(request, Constants.AUTHORIZATION_HEADER, Constants.BEARER_PREFIX)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_HEADER_ERROR));
-        signUpOauthUseCase.execute(temporaryToken, requestDto);
-        return ResponseDto.created(null);
+        return ResponseDto.created(signUpOauthUseCase.execute(temporaryToken, requestDto));
     }
 
     /**


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #449 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [ ] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 회원가입 시 곧바로 JWT 발급하도록 변경

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원가입(기본 및 소셜) 완료 시 JWT 토큰이 즉시 발급되어 응답으로 반환됩니다.

- **버그 수정**
    - 회원가입 후 반환값이 없던 문제를 해결하여, 이제 회원가입 요청 시 토큰 정보를 정상적으로 받을 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->