### PR TITLE
✨ Feature - 4.1.9 회원 스캔 가격 계산하기 API 구현

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/application/service/EstimateUserOrderPriceService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/EstimateUserOrderPriceService.java
@@ -1,0 +1,86 @@
+package com.tookscan.tookscan.order.application.service;
+
+import com.tookscan.tookscan.account.domain.User;
+import com.tookscan.tookscan.address.domain.Address;
+import com.tookscan.tookscan.order.application.usecase.EstimateUserOrderPriceUseCase;
+import com.tookscan.tookscan.order.domain.Coupon;
+import com.tookscan.tookscan.order.domain.Delivery;
+import com.tookscan.tookscan.order.domain.Document;
+import com.tookscan.tookscan.order.domain.Order;
+import com.tookscan.tookscan.order.domain.PricePolicy;
+import com.tookscan.tookscan.order.domain.service.CouponService;
+import com.tookscan.tookscan.order.domain.service.DeliveryService;
+import com.tookscan.tookscan.order.domain.service.DocumentService;
+import com.tookscan.tookscan.order.domain.service.OrderService;
+import com.tookscan.tookscan.order.domain.type.EDeliveryStatus;
+import com.tookscan.tookscan.order.presentation.dto.request.EstimateUserOrderPriceRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.response.EstimateUserOrderPriceResponseDto;
+import com.tookscan.tookscan.order.repository.CouponRepository;
+import com.tookscan.tookscan.order.repository.PricePolicyRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EstimateUserOrderPriceService implements EstimateUserOrderPriceUseCase {
+
+    private final PricePolicyRepository pricePolicyRepository;
+    private final CouponRepository couponRepository;
+
+    private final OrderService orderService;
+    private final DocumentService documentService;
+    private final DeliveryService deliveryService;
+    private final CouponService couponService;
+
+    @Override
+    @Transactional
+    public EstimateUserOrderPriceResponseDto execute(EstimateUserOrderPriceRequestDto requestDto) {
+        // 가격 정책 조회
+        PricePolicy pricePolicy = pricePolicyRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqualOrElseThrow(
+                LocalDate.now(), LocalDate.now());
+
+        Coupon coupon = null;
+
+        // 쿠폰 조회
+        if (requestDto.couponId() != null) {
+            coupon = couponRepository.findByIdOrElseThrow(requestDto.couponId());
+        }
+        User user = null;
+        Address address = null;
+
+        // 배송 정보 생성
+        Delivery delivery = deliveryService.createDelivery(
+                "",
+                "",
+                "",
+                EDeliveryStatus.POST_WAITING,
+                "",
+                address,
+                pricePolicy.getDeliveryPrice()
+        );
+
+        // 주문 생성
+        Order order = orderService.createOrder(user, true, delivery, coupon, requestDto.isOneDayScan());
+
+        // 쿠폰 적용
+        if (coupon != null) {
+            couponService.applyCoupon(coupon, order);
+        }
+
+        // 문서 생성
+        requestDto.documents().forEach(doc -> {
+            Document document = documentService.createDocument(
+                    doc.name(),
+                    doc.pageCount(),
+                    doc.recoveryOption(),
+                    order,
+                    pricePolicy
+            );
+            order.getDocuments().add(document);
+        });
+
+        return EstimateUserOrderPriceResponseDto.fromEntity(order);
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/usecase/EstimateUserOrderPriceUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/usecase/EstimateUserOrderPriceUseCase.java
@@ -1,0 +1,10 @@
+package com.tookscan.tookscan.order.application.usecase;
+
+import com.tookscan.tookscan.core.annotation.bean.UseCase;
+import com.tookscan.tookscan.order.presentation.dto.request.EstimateUserOrderPriceRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.response.EstimateUserOrderPriceResponseDto;
+
+@UseCase
+public interface EstimateUserOrderPriceUseCase {
+    EstimateUserOrderPriceResponseDto execute(EstimateUserOrderPriceRequestDto requestDto);
+}

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderUserQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderUserQueryV1Controller.java
@@ -2,12 +2,15 @@ package com.tookscan.tookscan.order.presentation.controller.query;
 
 import com.tookscan.tookscan.core.annotation.security.AccountID;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.order.application.usecase.EstimateUserOrderPriceUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderCouponDetailUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderDeliveryUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderDetailUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderOverviewUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderSummaryUseCase;
 import com.tookscan.tookscan.order.domain.type.EOrderStatus;
+import com.tookscan.tookscan.order.presentation.dto.request.EstimateUserOrderPriceRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.response.EstimateUserOrderPriceResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadUserOrderCouponDetailResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadUserOrderDeliveryResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadUserOrderDetailResponseDto;
@@ -16,11 +19,14 @@ import com.tookscan.tookscan.order.presentation.dto.response.ReadUserOrderSummar
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +41,19 @@ public class OrderUserQueryV1Controller {
     private final ReadUserOrderSummaryUseCase readUserOrderSummaryUseCase;
     private final ReadUserOrderDeliveryUseCase readUserOrderDeliveryUseCase;
     private final ReadUserOrderCouponDetailUseCase readUserOrderCouponDetailUseCase;
+    private final EstimateUserOrderPriceUseCase estimateUserOrderPriceUseCase;
+
+    /**
+     * 4.1.9 회원 스캔 가격 계산
+     */
+    @Operation(summary = "회원 스캔 가격 계산", description = "회원이 스캔 가격을 계산합니다.")
+    @PostMapping(value = "/estimate")
+    public ResponseDto<EstimateUserOrderPriceResponseDto> estimateOrderPrice(
+            @Parameter(hidden = true) @AccountID UUID accountId,
+            @RequestBody @Valid EstimateUserOrderPriceRequestDto requestDto
+    ) {
+        return ResponseDto.ok(estimateUserOrderPriceUseCase.execute(requestDto));
+    }
 
     /**
      * 4.2.2 회원 주문 내역 조회

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/EstimateUserOrderPriceRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/EstimateUserOrderPriceRequestDto.java
@@ -1,0 +1,51 @@
+package com.tookscan.tookscan.order.presentation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tookscan.tookscan.core.validator.ByteSize;
+import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+
+public record EstimateUserOrderPriceRequestDto(
+        @JsonProperty("documents")
+        @Valid
+        @NotEmpty(message = "문서를 1개 이상 입력해주세요.")
+        List<RequestDocument> documents,
+
+        @JsonProperty("coupon_id")
+        Long couponId,
+
+        @JsonProperty("is_one_day_scan")
+        @NotNull(message = "원데이 스캔 여부를 입력해주세요.")
+        Boolean isOneDayScan
+) {
+    public record RequestDocument(
+
+            @JsonProperty("name")
+            @NotBlank(message = "문서 이름을 입력해주세요.")
+            @ByteSize(min = 2, max = 100, message = "문서 이름의 크기는 최소 2바이트 ~ 최대 100바이트 입니다.")
+            @Pattern(
+                    regexp = "^(?! )[A-Za-z0-9가-힣 ]{2,100}(?<! )$",
+                    message = "문서 이름은 2~100자(한글/영문/숫자/내부공백)이며, 양 끝 공백 및 특수문자는 허용되지 않습니다."
+            )
+            String name,
+
+            @NotNull(message = "페이지 수를 입력해주세요.")
+            @Min(value = 0, message = "페이지 수는 0 이상이어야 합니다.")
+            @Max(value = 10000, message = "페이지 수는 10000 이하이어야 합니다.")
+            @JsonProperty("page_count")
+            Integer pageCount,
+
+            @NotNull(message = "복원 옵션을 입력해주세요.")
+            @JsonProperty("recovery_option")
+            ERecoveryOption recoveryOption
+    ) {
+    }
+}
+

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/EstimateUserOrderPriceResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/EstimateUserOrderPriceResponseDto.java
@@ -1,0 +1,170 @@
+package com.tookscan.tookscan.order.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tookscan.tookscan.core.dto.SelfValidating;
+import com.tookscan.tookscan.order.domain.Document;
+import com.tookscan.tookscan.order.domain.Order;
+import com.tookscan.tookscan.order.domain.type.ECouponType;
+import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUserOrderPriceResponseDto> {
+    @JsonProperty("documents")
+    @NotNull
+    private final List<DocumentInfoDto> documents;
+
+    @JsonProperty("documents_price")
+    private final Integer documentsPrice;
+
+    @JsonProperty("one_day_scan_price")
+    private final Integer oneDayScanPrice;
+
+    @JsonProperty("delivery_price")
+    private final Integer deliveryPrice;
+
+    @JsonProperty("recovery_price")
+    private final Integer recoveryPrice;
+
+    @JsonProperty("cutting_price")
+    private final Integer cuttingPrice;
+
+    @JsonProperty("coupon_type")
+    private final ECouponType couponType;
+
+    @JsonProperty("coupon_price")
+    private final Integer couponPrice;
+
+    @JsonProperty("coupon_percentage")
+    private final Integer couponPercentage;
+
+    @JsonProperty("payment_total")
+    private final Integer paymentTotal;
+
+    @Getter
+    @Valid
+    public static class DocumentInfoDto extends SelfValidating<DocumentInfoDto> {
+        @JsonProperty("name")
+        @NotNull
+        private final String name;
+
+        @JsonProperty("page_count")
+        @NotNull
+        private final Integer pageCount;
+
+        @JsonProperty("document_price")
+        @NotNull
+        private final Integer documentPrice;
+
+        @JsonProperty("recovery_option")
+        @NotNull
+        private final ERecoveryOption recoveryOption;
+
+        @JsonProperty("recovery_price")
+        @NotNull
+        private final Integer recoveryPrice;
+
+        @JsonProperty("one_day_scan_price")
+        @NotNull
+        private final Integer oneDayScanPrice;
+
+        @JsonProperty("cutting_price")
+        @NotNull
+        private final Integer cuttingPrice;
+
+        @Builder
+        public DocumentInfoDto(String name,
+                               Integer pageCount,
+                               Integer documentPrice,
+                               ERecoveryOption recoveryOption,
+                               Integer recoveryPrice,
+                               Integer oneDayScanPrice,
+                               Integer cuttingPrice) {
+            this.name = name;
+            this.pageCount = pageCount;
+            this.documentPrice = documentPrice;
+            this.recoveryOption = recoveryOption;
+            this.recoveryPrice = recoveryPrice;
+            this.oneDayScanPrice = oneDayScanPrice;
+            this.cuttingPrice = cuttingPrice;
+            this.validateSelf();
+        }
+
+        public static DocumentInfoDto fromEntity(Document document) {
+            return DocumentInfoDto.builder()
+                    .name(document.getName())
+                    .pageCount(document.getPageCount())
+                    .documentPrice(document.calculateDocumentPrice())
+                    .recoveryOption(document.getRecoveryOption())
+                    .recoveryPrice(document.getRecoveryOption().getPrice())
+                    .oneDayScanPrice(document.calculateOneDayScanPrice() - document.calculateDocumentPrice())
+                    .cuttingPrice(document.getPricePolicy().getDefaultPrice())
+                    .build();
+        }
+    }
+
+    @Builder
+    public EstimateUserOrderPriceResponseDto(
+            List<DocumentInfoDto> documents,
+            Integer documentsPrice,
+            Integer oneDayScanPrice,
+            Integer deliveryPrice,
+            Integer recoveryPrice,
+            Integer cuttingPrice,
+            ECouponType couponType,
+            Integer couponPrice,
+            Integer couponPercentage,
+            Integer paymentTotal
+    ) {
+        this.documents = documents;
+        this.documentsPrice = documentsPrice;
+        this.oneDayScanPrice = oneDayScanPrice;
+        this.deliveryPrice = deliveryPrice;
+        this.recoveryPrice = recoveryPrice;
+        this.cuttingPrice = cuttingPrice;
+        this.couponType = couponType;
+        this.couponPrice = couponPrice;
+        this.couponPercentage = couponPercentage;
+        this.paymentTotal = paymentTotal;
+        this.validateSelf();
+    }
+
+    public static EstimateUserOrderPriceResponseDto fromEntity(Order order) {
+        List<DocumentInfoDto> docs = order.getDocuments().stream()
+                .map(DocumentInfoDto::fromEntity)
+                .toList();
+
+        int docsPriceSum = docs.stream()
+                .mapToInt(DocumentInfoDto::getDocumentPrice)
+                .sum();
+
+        int oneDayScanPriceSum = docs.stream()
+                .mapToInt(DocumentInfoDto::getOneDayScanPrice)
+                .sum();
+
+        int cuttingPriceSum = docs.stream()
+                .mapToInt(DocumentInfoDto::getCuttingPrice)
+                .sum();
+
+        int recoveryPriceSum = docs.stream()
+                .mapToInt(DocumentInfoDto::getRecoveryPrice)
+                .sum();
+
+        return EstimateUserOrderPriceResponseDto.builder()
+                .documents(docs)
+                .couponType(order.getCoupon() != null ? order.getCoupon().getType() : null)
+                .couponPercentage(order.getCoupon() != null ? order.getCoupon().getDiscountPercent() : null)
+                .documentsPrice(docsPriceSum)
+                .oneDayScanPrice(oneDayScanPriceSum)
+                .deliveryPrice(order.getDelivery().getDeliveryPrice())
+                .recoveryPrice(recoveryPriceSum)
+                .cuttingPrice(cuttingPriceSum)
+                .couponPrice(order.getCoupon() != null ? order.getCoupon().getDiscountPrice() : null)
+                .paymentTotal(order.getTotalAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderDetailResponseDto.java
@@ -83,6 +83,9 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
     @JsonProperty("delivery_price")
     private final Integer deliveryPrice;
 
+    @JsonProperty("recovery_price")
+    private final Integer recoveryPrice;
+
     @JsonProperty("cutting_price")
     private final Integer cuttingPrice;
 
@@ -156,7 +159,7 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
                     .documentPrice(document.calculateDocumentPrice())
                     .recoveryOption(document.getRecoveryOption())
                     .recoveryPrice(document.getRecoveryOption().getPrice())
-                    .oneDayScanPrice(document.calculateOneDayScanPrice())
+                    .oneDayScanPrice(document.calculateOneDayScanPrice() - document.calculateDocumentPrice())
                     .cuttingPrice(document.getPricePolicy().getDefaultPrice())
                     .build();
         }
@@ -181,6 +184,7 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
             Integer documentsPrice,
             Integer oneDayScanPrice,
             Integer deliveryPrice,
+            Integer recoveryPrice,
             Integer cuttingPrice,
             ECouponType couponType,
             Integer couponPrice,
@@ -206,6 +210,7 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
         this.documentsPrice = documentsPrice;
         this.oneDayScanPrice = oneDayScanPrice;
         this.deliveryPrice = deliveryPrice;
+        this.recoveryPrice = recoveryPrice;
         this.cuttingPrice = cuttingPrice;
         this.couponType = couponType;
         this.couponPrice = couponPrice;
@@ -240,6 +245,10 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
                 .mapToInt(DocumentInfoDto::getCuttingPrice)
                 .sum();
 
+        int recoveryPriceSum = docs.stream()
+                .mapToInt(DocumentInfoDto::getRecoveryPrice)
+                .sum();
+
         String couponName = order.getCoupon() != null
                 ? order.getCoupon().getName()
                 : null;
@@ -269,6 +278,7 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
                 .documentsPrice(docsPriceSum)
                 .oneDayScanPrice(oneDayScanPriceSum)
                 .deliveryPrice(order.getDelivery().getDeliveryPrice())
+                .recoveryPrice(recoveryPriceSum)
                 .cuttingPrice(cuttingPriceSum)
                 .couponPrice(order.getCoupon() != null ? order.getCoupon().getDiscountPrice() : null)
                 .paymentTotal(paymentOpt.map(Payment::getTotalAmount).orElse(order.getTotalAmount()))

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderDetailResponseDto.java
@@ -56,10 +56,6 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
     @NotNull
     private final String email;
 
-    @JsonProperty("zone_code")
-    @NotNull
-    private final String zoneCode;
-
     @JsonProperty("address")
     @NotNull
     private final AddressResponseDto address;
@@ -70,6 +66,10 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
     @JsonProperty("documents")
     @NotNull
     private final List<DocumentInfoDto> documents;
+
+    @JsonProperty("is_one_day_scan")
+    @NotNull
+    private final Boolean isOneDayScan;
 
     @JsonProperty("coupon_name")
     private final String couponName;
@@ -177,10 +177,10 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
             String phoneNumber,
             String receiverName,
             String email,
-            String zoneCode,
             AddressResponseDto address,
             String deliveryRequest,
             List<DocumentInfoDto> documents,
+            Boolean isOneDayScan,
             Integer documentsPrice,
             Integer oneDayScanPrice,
             Integer deliveryPrice,
@@ -203,10 +203,10 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
         this.phoneNumber = phoneNumber;
         this.receiverName = receiverName;
         this.email = email;
-        this.zoneCode = zoneCode;
         this.address = address;
         this.deliveryRequest = deliveryRequest;
         this.documents = documents;
+        this.isOneDayScan = isOneDayScan;
         this.documentsPrice = documentsPrice;
         this.oneDayScanPrice = oneDayScanPrice;
         this.deliveryPrice = deliveryPrice;
@@ -268,10 +268,10 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
                 .phoneNumber(order.getDelivery().getPhoneNumber())
                 .receiverName(order.getDelivery().getReceiverName())
                 .email(order.getDelivery().getEmail())
-                .zoneCode(order.getDelivery().getAddress().getZoneCode())
                 .address(AddressResponseDto.fromEntity(order.getDelivery().getAddress()))
                 .deliveryRequest(order.getDelivery().getRequest())
                 .documents(docs)
+                .isOneDayScan(order.getIsOneDayScan())
                 .couponName(couponName)
                 .couponType(order.getCoupon() != null ? order.getCoupon().getType() : null)
                 .couponPercentage(order.getCoupon() != null ? order.getCoupon().getDiscountPercent() : null)


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #476 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 4.1.9 회원 스캔 가격 계산하기 API 구현

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 사용자가 주문 가격을 사전 계산할 수 있는 견적 조회 API가 추가되었습니다.
    - 주문 견적 요청 및 응답을 위한 데이터 전송 객체(DTO)가 도입되었습니다.

- **버그 수정**
    - 주문 상세 응답에서 zoneCode(우편번호) 필드가 제거되었습니다.
    - 주문 및 문서 상세에서 당일 스캔 여부와 복원 가격 정보가 추가되었습니다.

- **기타**
    - 주문 견적 계산 및 응답 구조가 개선되어, 문서별 상세 가격 정보와 쿠폰 적용 내역을 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->