### PR TITLE
🔨 Fix - 로그인 유지 시 체크한 경우와 아닌 경우의 refresh_cookie 유효기간 차별화

### DIFF
--- a/http/auth/AuthControllerHttpRequest.http
+++ b/http/auth/AuthControllerHttpRequest.http
@@ -4,7 +4,8 @@ POST {{host_url}}/v1/auth/login
 Content-Type: application/x-www-form-urlencoded
 
 serial_id={{auth.API_1_1_1_USER.serial_id}}&
-password={{auth.API_1_1_1_USER.password}}
+password={{auth.API_1_1_1_USER.password}}&
+remember_me=true
 
 ### 1.1.1 관리자 일반 로그인
 // @no-log

--- a/src/main/java/com/tookscan/tookscan/core/constant/Constants.java
+++ b/src/main/java/com/tookscan/tookscan/core/constant/Constants.java
@@ -13,10 +13,11 @@ public class Constants {
     public static String BEARER_PREFIX = "Bearer ";
     public static String AUTHORIZATION_HEADER = "Authorization";
 
-    // COOKIE
+    // TOKEN
     public static String ACCESS_TOKEN = "access_token";
     public static String REFRESH_TOKEN = "refresh_token";
     public static String TEMPORARY_TOKEN = "temporary_token";
+    public static String REMEMBER_ME = "remember_me";
 
     // Oauth2 Href URL
     public static String KAKAO_OAUTH2_HREF = "/oauth2/authorization/kakao";

--- a/src/main/java/com/tookscan/tookscan/core/utility/CookieUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/CookieUtil.java
@@ -47,6 +47,7 @@ public class CookieUtil {
                 .domain(cookieDomain)
                 .path("/")
                 .httpOnly(true)
+                .maxAge(60 * 60) // 1 hour
                 .sameSite("Lax")
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/com/tookscan/tookscan/core/utility/HttpServletUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/HttpServletUtil.java
@@ -88,6 +88,37 @@ public class HttpServletUtil {
                 cookieDomain,
                 Constants.REFRESH_TOKEN,
                 tokenDto.getRefreshToken(),
+                (int) (refreshTokenExpirePeriod / 10000L) // 기존 기한의 10분의 1로 설정 (로그인 유지 체크 안함)
+        );
+
+        Map<String, Object> result = new HashMap<>();
+
+        result.put("success", true);
+        result.put("data", null);
+        result.put("error", null);
+
+        response.getWriter().write(objectMapper.writeValueAsString(result));
+    }
+
+    public void onSuccessBodyResponseWithJWTCookieRememberMeTrue(
+            HttpServletResponse response,
+            DefaultJsonWebTokenDto tokenDto
+    ) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.CREATED.value());
+
+        CookieUtil.addCookie(
+                response,
+                cookieDomain,
+                Constants.ACCESS_TOKEN,
+                tokenDto.getAccessToken()
+        );
+        CookieUtil.addSecureCookie(
+                response,
+                cookieDomain,
+                Constants.REFRESH_TOKEN,
+                tokenDto.getRefreshToken(),
                 (int) (refreshTokenExpirePeriod / 1000L)
         );
 

--- a/src/main/java/com/tookscan/tookscan/security/handler/login/DefaultLoginSuccessHandler.java
+++ b/src/main/java/com/tookscan/tookscan/security/handler/login/DefaultLoginSuccessHandler.java
@@ -24,12 +24,16 @@ public class DefaultLoginSuccessHandler implements AuthenticationSuccessHandler 
     private final JsonWebTokenUtil jwtUtil;
     private final HttpServletUtil httpServletUtil;
 
+    private static final String TRUE = "true";
+
     @Override
     public void onAuthenticationSuccess(
             HttpServletRequest request,
             HttpServletResponse response,
             Authentication authentication
     ) throws IOException {
+        String rememberMe = request.getParameter(Constants.REMEMBER_ME);
+
         CustomUserPrincipal principal = (CustomUserPrincipal) authentication.getPrincipal();
 
         DefaultJsonWebTokenDto jsonWebTokenDto = jwtUtil.generateDefaultJsonWebTokens(
@@ -39,6 +43,10 @@ public class DefaultLoginSuccessHandler implements AuthenticationSuccessHandler 
 
         loginByDefaultUseCase.execute(principal, jsonWebTokenDto);
 
-        httpServletUtil.onSuccessBodyResponseWithJWTCookie(response, jsonWebTokenDto);
+        if (rememberMe != null && rememberMe.equals(TRUE)) {
+            httpServletUtil.onSuccessBodyResponseWithJWTCookieRememberMeTrue(response, jsonWebTokenDto);
+        } else {
+            httpServletUtil.onSuccessBodyResponseWithJWTCookie(response, jsonWebTokenDto);
+        }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #511 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 로그인 유지 시 체크한 경우와 아닌 경우의 refresh_cookie 유효기간 차별화

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 로그인 시 "로그인 상태 유지(remember me)" 옵션을 지원합니다. 해당 옵션을 선택하면 리프레시 토큰의 만료 기간이 연장되어 오랜 기간 동안 로그인 상태가 유지됩니다.

- **버그 수정**
  - 쿠키의 유효 기간이 명확하게 1시간으로 설정되어 세션 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->