### PR TITLE
🔨 Fix - 주문 가격 계산하기 API 배송비 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/application/service/CreateUserOrderService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/CreateUserOrderService.java
@@ -16,6 +16,7 @@ import com.tookscan.tookscan.order.domain.service.DeliveryService;
 import com.tookscan.tookscan.order.domain.service.DocumentService;
 import com.tookscan.tookscan.order.domain.service.OrderService;
 import com.tookscan.tookscan.order.domain.type.EDeliveryStatus;
+import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
 import com.tookscan.tookscan.order.presentation.dto.request.CreateUserOrderRequestDto;
 import com.tookscan.tookscan.order.presentation.dto.response.CreateUserOrderResponseDto;
 import com.tookscan.tookscan.order.repository.CouponRepository;
@@ -82,6 +83,11 @@ public class CreateUserOrderService implements CreateUserOrderUseCase {
                 .orElse(null);
 
         // 배송 정보 생성
+        Integer deliveryPrice = 0;
+        if (requestDto.documents().stream()
+                .anyMatch(document -> document.recoveryOption() != ERecoveryOption.DISCARD)) {
+            deliveryPrice = pricePolicy.getDeliveryPrice();
+        }
         Delivery delivery = deliveryService.createDelivery(
                 requestDto.deliveryInfo().receiverName(),
                 requestDto.deliveryInfo().phoneNumber(),
@@ -89,7 +95,7 @@ public class CreateUserOrderService implements CreateUserOrderUseCase {
                 EDeliveryStatus.POST_WAITING,
                 requestDto.deliveryInfo().request(),
                 address,
-                pricePolicy.getDeliveryPrice()
+                deliveryPrice
         );
         deliveryRepository.save(delivery);
 

--- a/src/main/java/com/tookscan/tookscan/order/application/service/EstimateUserOrderPriceService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/EstimateUserOrderPriceService.java
@@ -13,6 +13,7 @@ import com.tookscan.tookscan.order.domain.service.DeliveryService;
 import com.tookscan.tookscan.order.domain.service.DocumentService;
 import com.tookscan.tookscan.order.domain.service.OrderService;
 import com.tookscan.tookscan.order.domain.type.EDeliveryStatus;
+import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
 import com.tookscan.tookscan.order.presentation.dto.request.EstimateUserOrderPriceRequestDto;
 import com.tookscan.tookscan.order.presentation.dto.response.EstimateUserOrderPriceResponseDto;
 import com.tookscan.tookscan.order.repository.CouponRepository;
@@ -51,6 +52,11 @@ public class EstimateUserOrderPriceService implements EstimateUserOrderPriceUseC
         Address address = null;
 
         // 배송 정보 생성
+        Integer deliveryPrice = 0;
+        if (requestDto.documents().stream()
+                .anyMatch(document -> document.recoveryOption() != ERecoveryOption.DISCARD)) {
+            deliveryPrice = pricePolicy.getDeliveryPrice();
+        }
         Delivery delivery = deliveryService.createDelivery(
                 "",
                 "",
@@ -58,7 +64,7 @@ public class EstimateUserOrderPriceService implements EstimateUserOrderPriceUseC
                 EDeliveryStatus.POST_WAITING,
                 "",
                 address,
-                pricePolicy.getDeliveryPrice()
+                deliveryPrice
         );
 
         // 주문 생성

--- a/src/main/java/com/tookscan/tookscan/order/domain/Order.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Order.java
@@ -200,10 +200,7 @@ public class Order extends BaseEntity {
             amount = coupon.calculatePrice(amount);
         }
 
-        if (documents.stream()
-                .anyMatch(document -> document.getRecoveryOption() != ERecoveryOption.DISCARD)) {
-           amount += delivery.getDeliveryPrice();
-        }
+        amount += delivery.getDeliveryPrice();
 
         return amount;
     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/EstimateUserOrderPriceResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/EstimateUserOrderPriceResponseDto.java
@@ -163,7 +163,7 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
                 .deliveryPrice(order.getDelivery().getDeliveryPrice())
                 .recoveryPrice(recoveryPriceSum)
                 .cuttingPrice(cuttingPriceSum)
-                .couponPrice(order.getCoupon() != null ? order.getCoupon().getDiscountPrice() : null)
+                .couponPrice(order.getCoupon() != null ? order.getCoupon().getDiscountPrice() : 0)
                 .paymentTotal(order.getTotalAmount())
                 .build();
     }

--- a/src/main/java/com/tookscan/tookscan/security/config/PricePolicyConfig.java
+++ b/src/main/java/com/tookscan/tookscan/security/config/PricePolicyConfig.java
@@ -18,7 +18,7 @@ public class PricePolicyConfig {
     private static final int DEFAULT_PRICE = 1000;
     private static final int PRICE_PER_PAGE = 10;
     private static final int PRICE_PER_PAGE_FOR_ONE_DAY_SCAN = 15;
-    private static final int DELIVERY_PRICE = 0;
+    private static final int DELIVERY_PRICE = 3000;
 
     @Bean
     public ApplicationRunner createPricePolicy() {


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #515 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 주문 가격 계산하기 API 배송비 수정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 쿠폰이 없는 경우 주문 금액 산정 응답에서 쿠폰 할인가가 null이 아닌 0으로 표시됩니다.
- **기능 개선**
  - 문서의 회수 옵션에 따라 배송비가 조건부로 적용됩니다.
  - 기본 배송비가 0원에서 3,000원으로 변경되었습니다.
  - 주문 금액 산정 시 배송비가 항상 포함되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->