### PR TITLE
⚙️ Setting - GitHub Actions에 AWS CloudWatch 로그 설정 추가

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -128,7 +128,7 @@ jobs:
             docker run -d \
               --name api-$NEXT \
               --env-file /home/ubuntu/.env.dev \
-              -p $PORT:8080 \
+              -p $PORT \
               -v /etc/localtime:/etc/localtime:ro \
               -v /etc/timezone:/etc/timezone:ro \
               --network ${{ secrets.DOCKER_NETWORKNAME }} \

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -134,6 +134,10 @@ jobs:
               --network ${{ secrets.DOCKER_NETWORKNAME }} \
               -v /home/ubuntu/aws:/app/aws \
               --stop-timeout 10 \
+              --log-driver=awslogs \
+              --log-opt awslogs-region=${{ secrets.AWS_REGION }} \
+              --log-opt awslogs-group=${{ secrets.DEV_AWS_LOG_GROUP }} \
+              --log-opt awslogs-stream=${{ secrets.DEV_AWS_LOG_STREAM }} \
               ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_DEV_REPONAME }}:latest
             
             for i in $(seq 1 30); do

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .vscode/*
 run-local.sh
 
+### ignore claude ###
+.claude/
+
 ### ignore env ###
 .env
 .env.*

--- a/claude.md
+++ b/claude.md
@@ -137,3 +137,51 @@ docker-compose -f docker-compose.local.yml up --build -d
 - 커밋 컨벤션: `type/#issue-number: description`
 - 코드 스타일: 기존 코드 패턴 준수
 - 테스트: 새로운 기능 추가 시 테스트 코드 작성 필수
+
+# Claude Code 프롬프트 모음
+
+## Issue 생성 프롬프트
+
+다음 정보를 기반으로 GitHub Issue를 생성하고 branch를 생성해 주세요.
+
+1. 기본 정보:
+
+- 조직 이름: TOOK-SCAN
+- 레포지토리 이름: TOOK-SCAN-Backend
+
+2. 이슈 제목 및 내용:
+
+- '.github/ISSUE_TEMPLATE/' 디렉터리 내부 파일 형식에 맞춰 작성
+    - 새로운 기능 추가: `feature.md` 파일 참고 (✨ Feature - 접두사)
+    - 버그 수정: `fix.md` 파일 참고 (🔨 Fix - 접두사)
+    - 코드 리팩토링: `refactor.md` 파일 참고 (♻️ Refactor - 접두사)
+    - 문서 수정: `docs.md` 파일 참고 (📃 Docs - 접두사)
+    - 설정 수정: `setting.md` 파일 참고 (⚙️ Setting - 접두사)
+    - 테스트 관련: `test.md` 파일 참고 (✅ Test - 접두사)
+    - 배포 관련: `deploy.md` 파일 참고 (🌏 Deploy - 접두사)
+    - 크로스 브라우징: `crossBrowsing.md` 파일 참고 (💻 CrossBrowsing - 접두사)
+
+3. 브랜치 이름:
+
+- 브랜치 이름은 `Type/#이슈번호` 형식으로 생성합니다.
+- Type은 대문자로 시작합니다 (Feature, Fix, Refactor, Docs, Setting, Test, Deploy, CrossBrowsing)
+- 예시: `Feature/#123`, `Fix/#456`
+
+## PR 생성 프롬프트
+
+다음 정보를 기반으로 GitHub PR을 생성해 주세요.
+
+1. 기본 정보:
+
+- 조직 이름: TOOK-SCAN
+- 레포지토리 이름: TOOK-SCAN-Backend
+- 타겟 브랜치: dev
+
+2. PR 제목:
+
+- 규칙: PR 제목은 이슈 제목과 동일하게 작성합니다.
+
+3. PR 내용:
+
+- '.github/pull_request_template.md' 파일 형식에 맞춰 작성
+- 현재 브랜치의 변경사항을 반영하여 상세하게 작성


### PR DESCRIPTION
## Related issue 🛠
closed #540

어떤 변경사항이 있었나요?
- [x] ⚙️ Setting: Development environment setup

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
GitHub Actions dev-cicd 워크플로에 AWS CloudWatch 로그 연동을 위한 설정을 추가했습니다.
- dev-cicd.yml에 Docker 컨테이너 awslogs 드라이버 설정 추가
- AWS_REGION, DEV_AWS_LOG_GROUP, DEV_AWS_LOG_STREAM을 secrets 변수로 설정
- Docker 컨테이너 로그를 CloudWatch로 중앙 집중 관리 가능

## Uncompleted Tasks 😅
GitHub repository secrets에 다음 값들을 추가해야 합니다:
- [ ] AWS_REGION 설정
- [ ] DEV_AWS_LOG_GROUP 설정  
- [ ] DEV_AWS_LOG_STREAM 설정

## To Reviewers 📢
- CloudWatch 로그 그룹과 스트림이 AWS에 미리 생성되어 있어야 합니다
- 배포 후 CloudWatch에서 로그가 정상적으로 수집되는지 확인이 필요합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD 배포 단계에서 Docker 컨테이너가 AWS CloudWatch 로그 설정을 사용하도록 개선되었습니다. 이제 배포된 컨테이너의 로그가 중앙에서 관리됩니다.
  * `.claude/` 디렉터리가 Git 관리에서 제외되도록 `.gitignore` 파일이 업데이트되었습니다.
* **Documentation**
  * TOOK-SCAN Backend 프로젝트용 GitHub 이슈 및 PR 작성 표준 프롬프트가 `claude.md`에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->