### PR TITLE
🔨 Fix - GitHub Actions Docker 포트 매핑 오류 수정

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -128,7 +128,7 @@ jobs:
             docker run -d \
               --name api-$NEXT \
               --env-file /home/ubuntu/.env.dev \
-              -p $PORT \
+              -p $PORT:8080 \
               -v /etc/localtime:/etc/localtime:ro \
               -v /etc/timezone:/etc/timezone:ro \
               --network ${{ secrets.DOCKER_NETWORKNAME }} \


### PR DESCRIPTION
## Related issue 🛠
closed #542

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
GitHub Actions dev-cicd 워크플로에서 Docker 포트 매핑 오류를 수정했습니다.
- `-p $PORT`를 `-p $PORT:8080`으로 수정
- Docker 포트 매핑 문법 오류로 인한 health check 실패 문제 해결
- Blue/Green 배포에서 호스트 포트와 컨테이너 포트 올바른 매핑 설정

**수정 전**: `-p $PORT` (잘못된 형식)
**수정 후**: `-p $PORT:8080` (호스트 포트:컨테이너 포트)

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- Blue/Green 배포 시 포트 매핑이 올바르게 작동하는지 확인해주세요
- Health check가 정상적으로 통과하는지 테스트가 필요합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Docker 컨테이너의 포트 매핑이 올바르게 설정되어, 호스트 포트와 컨테이너의 8080 포트 간의 연결이 정상적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->