### PR TITLE
📃 Docs - Swagger 에러코드 문서화 시스템 구현

### DIFF
--- a/src/main/java/com/tookscan/tookscan/account/presentation/controller/command/AccountAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/account/presentation/controller/command/AccountAdminCommandV1Controller.java
@@ -11,7 +11,10 @@ import com.tookscan.tookscan.account.application.usecase.DeleteAdminGroupUseCase
 import com.tookscan.tookscan.account.application.usecase.DeleteAdminUserUseCase;
 import com.tookscan.tookscan.account.application.usecase.UpdateAdminGroupUseCase;
 import com.tookscan.tookscan.account.application.usecase.UpdateAdminUserUseCase;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -41,6 +44,12 @@ public class AccountAdminCommandV1Controller {
     /**
      * 3.1.1 (관리자) 그룹 만들기
      */
+    @Operation(summary = "관리자 그룹 생성", description = "관리자가 새로운 그룹을 생성합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.ALREADY_EXIST_RESOURCE,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping("/groups")
     public ResponseDto<Void> createAdminGroup(
             @RequestBody @Valid CreateAdminGroupRequestDto requestDto
@@ -52,6 +61,13 @@ public class AccountAdminCommandV1Controller {
     /**
      * 3.3.1 (관리자) 그룹 수정
      */
+    @Operation(summary = "관리자 그룹 수정", description = "관리자가 기존 그룹 정보를 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_USER_GROUP,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.ALREADY_EXIST_RESOURCE,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping("/groups/{id}")
     public ResponseDto<Void> updateAdminGroup(
             @PathVariable Long id,
@@ -64,6 +80,12 @@ public class AccountAdminCommandV1Controller {
     /**
      * 3.4.2 (관리자) 유저 정보 수정
      */
+    @Operation(summary = "관리자 유저 정보 수정", description = "관리자가 사용자 정보를 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.ACCESS_DENIED
+    })
     @PutMapping("/users/{id}")
     public ResponseDto<Void> updateAdminUser(
             @RequestBody @Valid UpdateAdminUserRequestDto requestDto,
@@ -76,6 +98,13 @@ public class AccountAdminCommandV1Controller {
     /**
      * 3.4.3 (관리자) 사용자 그룹 지정
      */
+    @Operation(summary = "관리자 사용자 그룹 지정", description = "관리자가 사용자들을 특정 그룹에 배정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_FOUND_USER_GROUP,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.ACCESS_DENIED
+    })
     @PutMapping("/groups/users")
     public ResponseDto<Void> createAdminUserGroup(
             @RequestBody @Valid CreateAdminUserGroupRequestDto requestDto
@@ -87,6 +116,12 @@ public class AccountAdminCommandV1Controller {
     /**
      * 3.5.1 (관리자) 그룹 삭제
      */
+    @Operation(summary = "관리자 그룹 삭제", description = "관리자가 기존 그룹을 삭제합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_USER_GROUP,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.ACCESS_DENIED
+    })
     @DeleteMapping("/groups/{id}")
     public ResponseDto<Void> deleteAdminGroup(
             @PathVariable Long id
@@ -98,6 +133,12 @@ public class AccountAdminCommandV1Controller {
     /**
      * 3.5.2 (관리자) 유저 삭제
      */
+    @Operation(summary = "관리자 유저 삭제", description = "관리자가 사용자들을 시스템에서 삭제합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.ACCESS_DENIED
+    })
     @DeleteMapping("/users")
     public ResponseDto<Void> deleteAdminUser(
             @RequestBody @Valid DeleteAdminUserRequestDto requestDto

--- a/src/main/java/com/tookscan/tookscan/account/presentation/controller/query/AccountAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/account/presentation/controller/query/AccountAdminQueryV1Controller.java
@@ -6,12 +6,17 @@ import com.tookscan.tookscan.account.presentation.dto.response.ReadAdminUserOver
 import com.tookscan.tookscan.account.application.usecase.ReadAdminGroupBriefUseCase;
 import com.tookscan.tookscan.account.application.usecase.ReadAdminUserDetailUseCase;
 import com.tookscan.tookscan.account.application.usecase.ReadAdminUserOverviewUseCase;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.web.bind.annotation.*;
+import com.tookscan.tookscan.security.domain.type.ESecurityProvider;
 
 import java.util.UUID;
 
@@ -28,6 +33,12 @@ public class AccountAdminQueryV1Controller {
     /**
      * 3.2.3 (관리자) 유저 상세 조회
      */
+    @Operation(summary = "유저 상세 조회", description = "관리자가 특정 유저의 상세 정보를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.ACCESS_DENIED,
+        ErrorCode.INVALID_ARGUMENT
+    })
     @GetMapping("/users/{id}/details")
     public ResponseDto<ReadAdminUserDetailResponseDto> readAdminUserDetail(
             @PathVariable("id") UUID id
@@ -38,25 +49,32 @@ public class AccountAdminQueryV1Controller {
     /**
      * 3.2.4 (관리자) 유저 리스트 조회
      */
+    @Operation(summary = "유저 리스트 조회", description = "관리자가 검색 조건에 따라 유저 리스트를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.INVALID_PARAMETER_FORMAT,
+        ErrorCode.INVALID_ENUM_TYPE,
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/users/overviews")
     public ResponseDto<ReadAdminUserOverviewResponseDto> readAdminUserOverview(
-            @RequestParam(value = "search-type", required = false) String searchType,
+            @Parameter(description = "검색 타입 (id, name, email, phone)") @RequestParam(value = "search-type", required = false) String searchType,
             @RequestParam(value = "search", required = false) String search,
             @RequestParam(value = "group-id", required = false) Long groupId,
-            @RequestParam(value = "provider", required = false) String provider,
+            @Parameter(description = "로그인 제공자 (DEFAULT, KAKAO, GOOGLE, NAVER)") @RequestParam(value = "provider", required = false) ESecurityProvider provider,
             @RequestParam(value = "start-date", required = false) String startDate,
             @RequestParam(value = "end-date", required = false) String endDate,
             @RequestParam(value = "page", defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다") Integer page,
             @RequestParam(value = "size", defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다") Integer size,
-            @RequestParam(value = "status", defaultValue = "all") String status,
-            @RequestParam(value = "sort", required = false) String sort,
+            @Parameter(description = "계정 상태 (all, active, inactive)") @RequestParam(value = "status", defaultValue = "all") String status,
+            @Parameter(description = "정렬 기준 (created-at, name, email)") @RequestParam(value = "sort", required = false) String sort,
             @RequestParam(value = "direction", defaultValue = "DESC") Direction direction
     ) {
         return ResponseDto.ok(readAdminUserOverviewUseCase.execute(
                 searchType,
                 search,
                 groupId,
-                provider,
+                provider != null ? provider.name() : null,
                 startDate,
                 endDate,
                 page,
@@ -70,6 +88,10 @@ public class AccountAdminQueryV1Controller {
     /**
      * 3.2.5 (관리자) 그룹 간단 정보 조회
      */
+    @Operation(summary = "그룹 간단 정보 조회", description = "관리자가 모든 그룹의 간단한 정보를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/groups/briefs")
     public ResponseDto<ReadAdminGroupBriefResponseDto> readAdminGroupBrief() {
         return ResponseDto.ok(readAdminGroupBriefUseCase.execute());

--- a/src/main/java/com/tookscan/tookscan/core/annotation/swagger/ApiErrorCode.java
+++ b/src/main/java/com/tookscan/tookscan/core/annotation/swagger/ApiErrorCode.java
@@ -1,0 +1,29 @@
+package com.tookscan.tookscan.core.annotation.swagger;
+
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 특정 API 엔드포인트에서 발생 가능한 에러 코드를 Swagger 문서에 자동으로 추가하는 어노테이션
+ * 
+ * 사용 예시:
+ * @ApiErrorCode(UserErrorCode.class)
+ * @GetMapping("/users/{id}")
+ * public ResponseEntity<User> getUser(@PathVariable Long id) { ... }
+ * 
+ * 이 어노테이션이 적용된 API는 Swagger UI에서 해당 에러 코드들의 상세한 응답 예시를 볼 수 있습니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCode {
+    /**
+     * 해당 API에서 발생할 수 있는 에러 코드들이 정의된 ErrorCode 배열
+     * 
+     * @return 에러 코드 배열
+     */
+    ErrorCode[] value();
+}

--- a/src/main/java/com/tookscan/tookscan/core/annotation/swagger/ApiErrorExceptions.java
+++ b/src/main/java/com/tookscan/tookscan/core/annotation/swagger/ApiErrorExceptions.java
@@ -1,0 +1,30 @@
+package com.tookscan.tookscan.core.annotation.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 특정 API 엔드포인트에서 발생 가능한 일반적인 예외들을 Swagger 문서에 자동으로 추가하는 어노테이션
+ * 
+ * 사용 예시:
+ * @ApiErrorExceptions({
+ *     MethodArgumentNotValidException.class,
+ *     MissingServletRequestParameterException.class
+ * })
+ * @PostMapping("/users")
+ * public ResponseEntity<User> createUser(@Valid @RequestBody CreateUserRequest request) { ... }
+ * 
+ * 이 어노테이션이 적용된 API는 Swagger UI에서 해당 예외들의 상세한 응답 예시를 볼 수 있습니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorExceptions {
+    /**
+     * 해당 API에서 발생할 수 있는 일반적인 예외 클래스들
+     * 
+     * @return 예외 클래스 배열
+     */
+    Class<? extends Exception>[] value();
+}

--- a/src/main/java/com/tookscan/tookscan/core/config/SwaggerConfig.java
+++ b/src/main/java/com/tookscan/tookscan/core/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.tookscan.tookscan.core.config;
 
+import com.tookscan.tookscan.core.config.swagger.ErrorCodeCustomizer;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -15,13 +16,16 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
 
     private static final String JWT_SCHEMA_NAME = "JWT TOKEN";
@@ -30,6 +34,8 @@ public class SwaggerConfig {
 
     @Value("${web-engine.server-url}")
     private String serverUrl;
+    
+    private final ErrorCodeCustomizer errorCodeCustomizer;
 
     @Bean
     public GroupedOpenApi publicApi() {
@@ -37,6 +43,7 @@ public class SwaggerConfig {
                 .group("public")
                 .pathsToMatch("/**")
                 .addOpenApiCustomizer(loginEndpointCustomiser())
+                .addOperationCustomizer(errorCodeCustomizer)
                 .build();
     }
 
@@ -45,6 +52,7 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
                 .group("user")
                 .pathsToMatch("/v1/users/**")
+                .addOperationCustomizer(errorCodeCustomizer)
                 .build();
     }
 
@@ -53,6 +61,7 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
                 .group("admin")
                 .pathsToMatch("/v1/admins/**")
+                .addOperationCustomizer(errorCodeCustomizer)
                 .build();
     }
 

--- a/src/main/java/com/tookscan/tookscan/core/config/swagger/ErrorCodeCustomizer.java
+++ b/src/main/java/com/tookscan/tookscan/core/config/swagger/ErrorCodeCustomizer.java
@@ -1,0 +1,183 @@
+package com.tookscan.tookscan.core.config.swagger;
+
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorExceptions;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.UnexpectedTypeException;
+import java.net.SocketTimeoutException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 에러 코드 예시를 Swagger 문서에 자동으로 추가하는 커스터마이저
+ * 
+ * @ApiErrorCode와 @ApiErrorExceptions 어노테이션이 적용된 API 메서드에 대해
+ * 해당 에러 코드들의 상세한 응답 예시를 Swagger UI에 표시합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ErrorCodeCustomizer implements OperationCustomizer {
+    
+    private static final String APPLICATION_JSON = "application/json";
+    
+    /**
+     * 일반적인 예외와 에러 코드 매핑 (GlobalExceptionHandler 기반)
+     */
+    private static final Map<Class<? extends Exception>, ErrorCode> EXCEPTION_ERROR_CODE_MAP = Map.ofEntries(
+        // Body Validation 검증 실패
+        Map.entry(MethodArgumentNotValidException.class, ErrorCode.INVALID_ARGUMENT),
+        
+        // 필수 파라미터 누락
+        Map.entry(MissingServletRequestParameterException.class, ErrorCode.MISSING_REQUEST_PARAMETER),
+        
+        // 메소드 인자 타입 불일치
+        Map.entry(MethodArgumentTypeMismatchException.class, ErrorCode.INVALID_PARAMETER_FORMAT),
+        
+        // Annotation Validation 검증 실패
+        Map.entry(HandlerMethodValidationException.class, ErrorCode.INVALID_ARGUMENT),
+        
+        // Constraint Validation 검증 실패
+        Map.entry(ConstraintViolationException.class, ErrorCode.INVALID_ARGUMENT),
+        
+        // 타입 불일치
+        Map.entry(UnexpectedTypeException.class, ErrorCode.INVALID_ARGUMENT),
+        
+        // JSON 변환 실패
+        Map.entry(HttpMessageNotReadableException.class, ErrorCode.BAD_REQUEST_JSON),
+        
+        // 지원되지 않는 미디어 타입
+        Map.entry(HttpMediaTypeNotSupportedException.class, ErrorCode.UNSUPPORTED_MEDIA_TYPE),
+        
+        // 지원되지 않는 HTTP 메소드
+        Map.entry(HttpRequestMethodNotSupportedException.class, ErrorCode.METHOD_NOT_ALLOWED),
+        
+        // 존재하지 않는 엔드포인트
+        Map.entry(NoHandlerFoundException.class, ErrorCode.NOT_FOUND_END_POINT),
+        
+        // 잘못된 인자
+        Map.entry(IllegalArgumentException.class, ErrorCode.INVALID_ARGUMENT),
+        
+        // 외부 서버 타임아웃
+        Map.entry(SocketTimeoutException.class, ErrorCode.EXTERNAL_SERVER_TIMEOUT),
+        
+        // 일반적인 서버 에러
+        Map.entry(Exception.class, ErrorCode.INTERNAL_SERVER_ERROR)
+    );
+    
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        ApiErrorCode apiErrorCode = handlerMethod.getMethodAnnotation(ApiErrorCode.class);
+        ApiErrorExceptions apiErrorExceptions = handlerMethod.getMethodAnnotation(ApiErrorExceptions.class);
+        
+        if (apiErrorCode != null) {
+            generateErrorCodeExamples(operation, apiErrorCode.value());
+        }
+        
+        if (apiErrorExceptions != null) {
+            generateExceptionExamples(operation, apiErrorExceptions.value());
+        }
+        
+        return operation;
+    }
+    
+    /**
+     * ErrorCode 배열을 기반으로 에러 응답을 생성합니다.
+     */
+    private void generateErrorCodeExamples(Operation operation, ErrorCode[] errorCodes) {
+        ApiResponses responses = operation.getResponses();
+        
+        Arrays.stream(errorCodes)
+            .forEach(errorCode -> {
+                String statusCode = String.valueOf(errorCode.getHttpStatus().value());
+                
+                // 에러 응답 생성
+                Map<String, Object> errorResponse = createErrorResponse(errorCode);
+                Example example = new Example();
+                example.setValue(errorResponse);
+                example.setSummary(errorCode.getMessage());
+                example.setDescription(String.format("[%d] %s", errorCode.getCode(), errorCode.getMessage()));
+                
+                // 기존 응답이 있는지 확인하고 없으면 새로 생성
+                ApiResponse apiResponse = responses.get(statusCode);
+                if (apiResponse == null) {
+                    apiResponse = new ApiResponse();
+                    apiResponse.setDescription(errorCode.getHttpStatus().getReasonPhrase());
+                    responses.put(statusCode, apiResponse);
+                }
+                
+                // Content와 MediaType 설정
+                Content content = apiResponse.getContent();
+                if (content == null) {
+                    content = new Content();
+                    apiResponse.setContent(content);
+                }
+                
+                MediaType mediaType = content.get(APPLICATION_JSON);
+                if (mediaType == null) {
+                    mediaType = new MediaType();
+                    content.addMediaType(APPLICATION_JSON, mediaType);
+                }
+                
+                // 예시 추가
+                if (mediaType.getExamples() == null) {
+                    mediaType.setExamples(new HashMap<>());
+                }
+                
+                String exampleKey = String.format("error_%d", errorCode.getCode());
+                mediaType.getExamples().put(exampleKey, example);
+            });
+    }
+    
+    /**
+     * Exception 클래스 배열을 기반으로 에러 응답을 생성합니다.
+     */
+    private void generateExceptionExamples(Operation operation, Class<? extends Exception>[] exceptionClasses) {
+        List<ErrorCode> errorCodes = Arrays.stream(exceptionClasses)
+            .map(EXCEPTION_ERROR_CODE_MAP::get)
+            .filter(errorCode -> errorCode != null)
+            .toList();
+        
+        if (!errorCodes.isEmpty()) {
+            generateErrorCodeExamples(operation, errorCodes.toArray(new ErrorCode[0]));
+        }
+    }
+    
+    /**
+     * ErrorCode를 기반으로 표준 에러 응답 구조를 생성합니다.
+     */
+    private Map<String, Object> createErrorResponse(ErrorCode errorCode) {
+        Map<String, Object> errorData = new HashMap<>();
+        errorData.put("code", errorCode.getCode());
+        errorData.put("message", errorCode.getMessage());
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", false);
+        response.put("data", null);
+        response.put("error", errorData);
+        
+        return response;
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/mail/presentation/controller/command/MailCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/mail/presentation/controller/command/MailCommandV1Controller.java
@@ -1,8 +1,11 @@
 package com.tookscan.tookscan.mail.presentation.controller.command;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.mail.presentation.dto.request.SendTestMailRequestDto;
 import com.tookscan.tookscan.mail.application.usecase.SendTestMailUseCase;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,13 @@ public class MailCommandV1Controller {
      * @param requestDto
      * @return
      */
+    @Operation(summary = "테스트 메일 발송", description = "지정된 이메일 주소로 테스트 메일을 발송합니다. 10분 내에 최대 4회까지 발송 가능합니다.")
+    @ApiErrorCode({
+        ErrorCode.TOO_MANY_TEST_MAIL_REQUESTS,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.EXTERNAL_SERVER_ERROR,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @PostMapping("/test-email")
     public ResponseDto<Void> sendTestMail(
             @RequestBody @Valid SendTestMailRequestDto requestDto

--- a/src/main/java/com/tookscan/tookscan/mail/presentation/controller/query/MailQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/mail/presentation/controller/query/MailQueryV1Controller.java
@@ -1,8 +1,11 @@
 package com.tookscan.tookscan.mail.presentation.controller.query;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.mail.presentation.dto.response.ReadTestMailStatusResponseDto;
 import com.tookscan.tookscan.mail.application.usecase.ReadTestMailStatusUseCase;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +21,11 @@ public class MailQueryV1Controller {
 
     private final ReadTestMailStatusUseCase readTestMailStatusUseCase;
 
+    @Operation(summary = "테스트 메일 발송 상태 조회", description = "지정된 이메일 주소로 테스트 메일이 발송되었는지 확인합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @GetMapping("/validation/test-email")
     public ResponseDto<ReadTestMailStatusResponseDto> readTestMailStatus(
             @RequestParam String email

--- a/src/main/java/com/tookscan/tookscan/notice/presentation/controller/command/NoticeAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/notice/presentation/controller/command/NoticeAdminCommandV1Controller.java
@@ -1,6 +1,8 @@
 package com.tookscan.tookscan.notice.presentation.controller.command;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.notice.application.usecase.CreateAdminNoticeUseCase;
 import com.tookscan.tookscan.notice.application.usecase.DeleteAdminNoticeUseCase;
 import com.tookscan.tookscan.notice.application.usecase.UpdateAdminNoticeUseCase;
@@ -30,6 +32,11 @@ public class NoticeAdminCommandV1Controller {
     private final DeleteAdminNoticeUseCase deleteAdminNoticeUseCase;
 
     @Operation(summary = "공지사항 등록", description = "새로운 공지사항을 등록합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @PostMapping
     public ResponseDto<Void> createNotice(
             @Valid @RequestBody CreateAdminNoticeRequestDto requestDto) {
@@ -38,6 +45,12 @@ public class NoticeAdminCommandV1Controller {
     }
 
     @Operation(summary = "공지사항 수정", description = "공지사항 정보를 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_NOTICE,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @PutMapping("/{noticeId}")
     public ResponseDto<ReadAdminNoticeDetailResponseDto> updateNotice(
             @PathVariable Long noticeId,
@@ -47,6 +60,12 @@ public class NoticeAdminCommandV1Controller {
     }
 
     @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_NOTICE,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @DeleteMapping("/{noticeId}")
     public ResponseDto<Object> deleteNotice(@PathVariable Long noticeId) {
         deleteAdminNoticeUseCase.execute(noticeId);

--- a/src/main/java/com/tookscan/tookscan/notice/presentation/controller/query/NoticeAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/notice/presentation/controller/query/NoticeAdminQueryV1Controller.java
@@ -1,6 +1,8 @@
 package com.tookscan.tookscan.notice.presentation.controller.query;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.notice.application.usecase.ReadAdminNoticeDetailUseCase;
 import com.tookscan.tookscan.notice.application.usecase.ReadAdminNoticeOverviewsUseCase;
 import com.tookscan.tookscan.notice.domain.type.ENoticeSearchType;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Sort.Direction;
 
 @Tag(name = "Notice", description = "Notice 관련 API 입니다.")
 @RestController
@@ -26,6 +29,12 @@ public class NoticeAdminQueryV1Controller {
     private final ReadAdminNoticeOverviewsUseCase readAdminNoticeOverviewsUseCase;
 
     @Operation(summary = "공지사항 상세 조회", description = "공지사항의 상세 정보를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_NOTICE,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @GetMapping("/{noticeId}/details")
     public ResponseDto<ReadAdminNoticeDetailResponseDto> getNotice(@PathVariable Long noticeId) {
         ReadAdminNoticeDetailResponseDto responseDto = readAdminNoticeDetailUseCase.execute(noticeId);
@@ -33,6 +42,11 @@ public class NoticeAdminQueryV1Controller {
     }
 
     @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회합니다. 검색, 정렬, 필터링, 페이지네이션을 지원합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @GetMapping("/overviews")
     public ResponseDto<ReadAdminNoticeOverviewsResponseDto> getNoticeList(
             @RequestParam(value = "page", defaultValue = "1") Integer page,
@@ -40,7 +54,7 @@ public class NoticeAdminQueryV1Controller {
             @RequestParam(value = "search", required = false) String search,
             @RequestParam(value = "search-type", required = false) String searchType,
             @RequestParam(value = "sort", defaultValue = "created-at") String sort,
-            @RequestParam(value = "direction", defaultValue = "desc") String direction,
+            @RequestParam(value = "direction", defaultValue = "desc") Direction direction,
             @RequestParam(value = "start-date", required = false) String startDate,
             @RequestParam(value = "end-date", required = false) String endDate,
             @RequestParam(value = "is-public", required = false) Boolean isPublic) {
@@ -50,7 +64,7 @@ public class NoticeAdminQueryV1Controller {
         ENoticeSortType sortEnum = ENoticeSortType.fromString(sort);
         
         ReadAdminNoticeOverviewsResponseDto responseDto = readAdminNoticeOverviewsUseCase.execute(
-                page, size, search, searchTypeEnum, sortEnum, direction, startDate, endDate, isPublic);
+                page, size, search, searchTypeEnum, sortEnum, direction.name().toLowerCase(), startDate, endDate, isPublic);
         return ResponseDto.ok(responseDto);
     }
 } 

--- a/src/main/java/com/tookscan/tookscan/notice/presentation/controller/query/NoticeUserQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/notice/presentation/controller/query/NoticeUserQueryV1Controller.java
@@ -1,6 +1,8 @@
 package com.tookscan.tookscan.notice.presentation.controller.query;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.notice.application.usecase.ReadUserNoticeDetailUseCase;
 import com.tookscan.tookscan.notice.application.usecase.ReadUserNoticeOverviewsUseCase;
 import com.tookscan.tookscan.notice.presentation.dto.response.ReadUserNoticeDetailResponseDto;
@@ -26,12 +28,23 @@ public class NoticeUserQueryV1Controller {
     private final ReadUserNoticeOverviewsUseCase readUserNoticeOverviewsUseCase;
 
     @Operation(summary = "공지사항 상세 조회", description = "공개된 공지사항의 상세 정보를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_NOTICE,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @GetMapping("/{noticeId}/details")
     public ResponseDto<ReadUserNoticeDetailResponseDto> getNotice(@PathVariable Long noticeId) {
         return ResponseDto.ok(readUserNoticeDetailUseCase.execute(noticeId));
     }
 
     @Operation(summary = "공지사항 목록 조회", description = "공개된 공지사항 목록을 생성일 기준 최신순으로 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    })
     @GetMapping("/overviews")
     public ResponseDto<ReadUserNoticeOverviewsResponseDto> getNoticeList(
             @RequestParam(value = "page", defaultValue = "1") Integer page,

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
@@ -1,7 +1,10 @@
 package com.tookscan.tookscan.order.presentation.controller.command;
 
 import com.tookscan.tookscan.core.annotation.security.AccountID;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorExceptions;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.utility.DateTimeUtil;
 import com.tookscan.tookscan.order.application.usecase.CreateAdminOrderCouponUseCase;
 import com.tookscan.tookscan.order.application.usecase.CreateAdminOrderMemoUseCase;
@@ -40,6 +43,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -125,6 +129,14 @@ public class OrderAdminCommandV1Controller {
      * 4.3.2 관리자 주문 상태 일괄 변경
      */
     @Operation(summary = "관리자 주문 상태 일괄 변경", description = "관리자가 여러 주문의 상태를 일괄 변경합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_ORDER,
+            ErrorCode.INVALID_ORDER_STATUS,
+            ErrorCode.ACCESS_DENIED
+    })
+    @ApiErrorExceptions({
+            MethodArgumentNotValidException.class
+    })
     @PostMapping(value = "/orders/status")
     public ResponseDto<Void> updateOrderStatus(
          @RequestBody @Valid UpdateAdminOrdersStatusRequestDto requestDto
@@ -137,6 +149,13 @@ public class OrderAdminCommandV1Controller {
      * 4.3.3 관리자 주문 메모 작성
      */
     @Operation(summary = "관리자 주문 메모 작성", description = "관리자가 주문에 메모를 작성합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_ORDER,
+            ErrorCode.ACCESS_DENIED
+    })
+    @ApiErrorExceptions({
+            MethodArgumentNotValidException.class
+    })
     @PostMapping(value = "/orders/{orderId}/memo")
     public ResponseDto<Void> createOrderMemo(
             @PathVariable Long orderId,

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
@@ -82,6 +82,11 @@ public class OrderAdminCommandV1Controller {
      * 4.1.3 관리자 배송 리스트 내보내기
      */
     @Operation(summary = "관리자 배송 리스트 내보내기", description = "관리자가 배송 리스트를 내보냅니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping(value = "/deliveries/export")
     public ResponseEntity<Resource> exportDeliveries(
             @RequestBody @Valid ExportAdminDeliveriesRequestDto requestDto
@@ -105,6 +110,12 @@ public class OrderAdminCommandV1Controller {
      * 4.1.5 관리자 쿠폰 등록
      */
     @Operation(summary = "관리자 쿠폰 등록", description = "관리자가 쿠폰을 등록합니다.")
+    @ApiErrorCode({
+        ErrorCode.ALREADY_EXIST_RESOURCE,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping(value = "/orders/coupons")
     public ResponseDto<CreateAdminOrderCouponRequestDto> createCoupon(
             @RequestBody @Valid CreateAdminOrderCouponRequestDto requestDto
@@ -117,6 +128,12 @@ public class OrderAdminCommandV1Controller {
      * 4.1.6 관리자 pdf 파일 업로드
      */
     @Operation(summary = "관리자 pdf 파일 업로드", description = "관리자가 pdf 파일을 업로드합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_DOCUMENT,
+        ErrorCode.UNSUPPORTED_MEDIA_TYPE,
+        ErrorCode.UPLOAD_FILE_ERROR,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping(value = "/documents/{documentId}/pdfs", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<Void> uploadPdf(
             @PathVariable Long documentId,
@@ -169,6 +186,12 @@ public class OrderAdminCommandV1Controller {
      * 4.3.4 관리자 배송지 정보 수정
      */
     @Operation(summary = "관리자 배송지 정보 수정", description = "관리자가 주문의 배송지 정보를 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_DELIVERY,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PutMapping(value = "/deliveries/{deliveryId}")
     public ResponseDto<Void> updateOrderAddress(
             @PathVariable Long deliveryId,
@@ -182,6 +205,11 @@ public class OrderAdminCommandV1Controller {
      * 4.3.5 관리자 파일 전송
      */
     @Operation(summary = "관리자 파일 전송", description = "관리자가 주문의 파일을 전송합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.INVALID_ORDER_STATUS,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping(value = "/orders/{id}/send-pdfs")
     public ResponseDto<Void> sendPdf(
             @PathVariable Long id
@@ -194,6 +222,11 @@ public class OrderAdminCommandV1Controller {
      * 4.3.7 관리자 결제 요청
      */
     @Operation(summary = "관리자 결제 요청", description = "관리자가 주문에 대해 결제를 요청합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.INVALID_ORDER_STATUS,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/orders/{id}/payment-requests")
     public ResponseDto<Void> requestPayment(
             @PathVariable Long id
@@ -206,6 +239,12 @@ public class OrderAdminCommandV1Controller {
      * 4.3.7 관리자 운송장 번호 등록
      */
     @Operation(summary = "관리자 운송장 번호 등록", description = "관리자가 주문에 운송장 번호를 등록합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_DELIVERY,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/deliveries/{deliveryId}/tracking-number")
     public ResponseDto<Void> updateOrderTrackingNumber(
             @PathVariable Long deliveryId,
@@ -219,6 +258,13 @@ public class OrderAdminCommandV1Controller {
      * 4.3.8 관리자 운송장 번호 일괄 등록
      */
     @Operation(summary = "관리자 운송장 번호 일괄 등록", description = "관리자가 여러 주문의 운송장 번호를 일괄 등록합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_DELIVERY,
+        ErrorCode.UNSUPPORTED_MEDIA_TYPE,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping(value = "/deliveries/tracking-number", consumes = "multipart/form-data")
     public ResponseDto<Void> updateOrderTrackingNumber(
             @RequestParam("file") MultipartFile file
@@ -231,6 +277,13 @@ public class OrderAdminCommandV1Controller {
      * 4.4.1 관리자 주문 상세 상품 수정
      */
     @Operation(summary = "관리자 주문 상세 상품 수정", description = "관리자가 주문의 상세 상품을 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_FOUND_PRICE_POLICY,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PutMapping(value = "orders/{orderId}")
     public ResponseDto<Void> updateOrderDocuments(
             @PathVariable Long orderId,
@@ -244,6 +297,12 @@ public class OrderAdminCommandV1Controller {
      * 4.5.1 관리자 주문 일괄 취소
      */
     @Operation(summary = "관리자 주문 일괄 취소", description = "관리자가 여러 주문을 취소합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/orders/cancel")
     public ResponseDto<Void> deleteOrders(
             @RequestBody @Valid UpdateAdminOrdersStatusCancelRequestDto requestDto
@@ -256,6 +315,12 @@ public class OrderAdminCommandV1Controller {
      * 4.5.2 관리자 상품 일괄 삭제
      */
     @Operation(summary = "관리자 상품 일괄 삭제", description = "관리자가 여러 상품을 삭제합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_DOCUMENT,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @DeleteMapping(value = "/documents")
     public ResponseDto<Void> deleteDocuments(
             @RequestBody @Valid DeleteAdminDocumentsRequestDto requestDto
@@ -268,6 +333,14 @@ public class OrderAdminCommandV1Controller {
      * 관리자 주문 일괄 복원 완료
      */
     @Operation(summary = "관리자 주문 일괄 복원 완료", description = "관리자가 여러 주문의 복원 작업을 완료합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_RECOVERY_IN_PROGRESS,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/orders/recovery-completed")
     public ResponseDto<Void> updateOrdersRecoveryCompleted(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -281,6 +354,13 @@ public class OrderAdminCommandV1Controller {
      * 관리자 주문 일괄 업체 도착 상태 변경
      */
     @Operation(summary = "관리자 주문 일괄 업체 도착 상태 변경", description = "관리자가 여러 주문의 상태를 업체 도착으로 일괄 변경합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_PAYMENT_COMPLETED,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/orders/company-arrived")
     public ResponseDto<Void> updateOrdersStatusCompanyArrived(
             @RequestBody @Valid UpdateAdminOrdersStatusCompanyArrivedRequestDto requestDto

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderUserCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderUserCommandV1Controller.java
@@ -1,7 +1,9 @@
 package com.tookscan.tookscan.order.presentation.controller.command;
 
 import com.tookscan.tookscan.core.annotation.security.AccountID;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.order.application.usecase.CreateUserOrderUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateUserOrderCancelUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateUserOrderHistoryUseCase;
@@ -37,6 +39,17 @@ public class OrderUserCommandV1Controller {
      * 4.1 회원 스캔 주문
      */
     @Operation(summary = "회원 스캔 주문", description = "회원이 주문을 생성합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_FOUND_PRICE_POLICY,
+        ErrorCode.NOT_FOUND_COUPON,
+        ErrorCode.NOT_AVAILABLE_COUPON,
+        ErrorCode.USED_COUPON,
+        ErrorCode.USER_ONLY_COUPON,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PostMapping()
     public ResponseDto<CreateUserOrderResponseDto> createOrder(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -50,6 +63,13 @@ public class OrderUserCommandV1Controller {
      * 4.3.9 회원 주문 취소하기
      */
     @Operation(summary = "회원 주문 취소하기", description = "회원이 주문을 취소합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_MATCH_ORDER_USER,
+        ErrorCode.NOT_UPDATABLE_ORDER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/{orderId}/cancel")
     public ResponseDto<Void> updateOrderCancel(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -63,6 +83,15 @@ public class OrderUserCommandV1Controller {
      * 4.3.10 회원 주문 정보 수정하기
      */
     @Operation(summary = "회원 주문 정보 수정하기", description = "회원이 주문 정보를 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_MATCH_ORDER_USER,
+        ErrorCode.NOT_UPDATABLE_ORDER,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/{orderId}/info")
     public ResponseDto<Void> updateOrderInfo(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -77,6 +106,16 @@ public class OrderUserCommandV1Controller {
      * 4.3.11 회원 주문 내역 수정하기
      */
     @Operation(summary = "회원 주문 내역 수정하기", description = "회원이 주문 내역을 수정합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_FOUND_PRICE_POLICY,
+        ErrorCode.NOT_MATCH_ORDER_USER,
+        ErrorCode.NOT_UPDATABLE_ORDER,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @PatchMapping(value = "/{orderId}/history")
     public ResponseDto<Void> updateOrderHistory(
             @Parameter(hidden = true) @AccountID UUID accountId,

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
@@ -1,6 +1,8 @@
 package com.tookscan.tookscan.order.presentation.controller.query;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminDocumentsPdfsUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderBriefsUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderDetailUseCase;
@@ -13,6 +15,7 @@ import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderDetai
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderOverviewsResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadStatisticsSummariesResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +42,9 @@ public class OrderAdminQueryV1Controller {
      * 4.2.5 관리자 주문 요약 정보 조회
      */
     @Operation(summary = "관리자 주문 요약 정보 조회", description = "관리자가 주문 요약 정보를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/orders/briefs")
     public ResponseDto<ReadAdminOrderBriefsResponseDto> readOrderBriefs() {
         return ResponseDto.ok(readAdminOrderBriefsUseCase.execute());
@@ -48,6 +54,10 @@ public class OrderAdminQueryV1Controller {
      * 4.2.7 관리자 스캔 파일 다운로드
      */
     @Operation(summary = "관리자 스캔 PDF 파일 다운로드", description = "관리자가 주문의 스캔 PDF 파일을 다운로드합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_DOCUMENT,
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/documents/{documentId}/pdfs")
     public ResponseDto<ReadAdminDocumentsPdfsResponseDto> downloadScanFile(
             @PathVariable Long documentId
@@ -59,6 +69,10 @@ public class OrderAdminQueryV1Controller {
      * 4.2.8 관리자 주문 상세 조회
      */
     @Operation(summary = "관리자 주문 상세 조회", description = "관리자가 주문 상세 내역을 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/orders/{orderId}/details")
     public ResponseDto<ReadAdminOrderDetailResponseDto> readOrderDocumentsOverviews(
             @PathVariable Long orderId
@@ -71,6 +85,11 @@ public class OrderAdminQueryV1Controller {
      * 4.2.12 관리자 주문 리스트 조회
      */
     @Operation(summary = "관리자 주문 리스트 조회", description = "관리자가 주문 리스트를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/orders/overviews")
     public ResponseDto<ReadAdminOrderOverviewsResponseDto> readOrderOverviews(
             @RequestParam(value = "page", defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다") Integer page,
@@ -78,8 +97,8 @@ public class OrderAdminQueryV1Controller {
             @RequestParam(value = "start-date", required = false) String startDate,
             @RequestParam(value = "end-date", required = false) String endDate,
             @RequestParam(value = "search", required = false) String search,
-            @RequestParam(value = "search-type", required = false) String searchType,
-            @RequestParam(value = "sort", defaultValue = "order-date") String sort,
+            @Parameter(description = "검색 타입 (id, name, email, phone, order-number)") @RequestParam(value = "search-type", required = false) String searchType,
+            @Parameter(description = "정렬 기준 (order-date, total-amount, document-count)") @RequestParam(value = "sort", defaultValue = "order-date") String sort,
             @RequestParam(value = "direction", defaultValue = "ASC") Direction direction,
             @RequestParam(value = "order-status", required = false) EOrderStatus orderStatus,
             @RequestParam(value = "is-one-day-scan", required = false) Boolean isOneDayScan,
@@ -88,8 +107,8 @@ public class OrderAdminQueryV1Controller {
             @RequestParam(value = "is-in-progress", required = false) Boolean isInProgress
     ) {
         return ResponseDto.ok(
-                readAdminOrderOverviewsUseCase.execute(page, size, startDate, endDate, search, searchType, sort,
-                        direction, orderStatus, isOneDayScan, hasRecoveryOption, isAsInProgress, isInProgress));
+                readAdminOrderOverviewsUseCase.execute(page, size, startDate, endDate, search, 
+                        searchType, sort, direction, orderStatus, isOneDayScan, hasRecoveryOption, isAsInProgress, isInProgress));
     }
 
 
@@ -97,6 +116,11 @@ public class OrderAdminQueryV1Controller {
      * 5.2.1 관리자 통계 조회
      */
     @Operation(summary = "관리자 통계 조회", description = "관리자가 통계 정보를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ACCESS_DENIED
+    })
     @GetMapping("/statistics/summaries")
     public ResponseDto<ReadStatisticsSummariesResponseDto> readStatisticsSummaries(
             @RequestParam(value = "start-year-month", required = false) String startYearMonth,

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderUserQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderUserQueryV1Controller.java
@@ -1,7 +1,9 @@
 package com.tookscan.tookscan.order.presentation.controller.query;
 
 import com.tookscan.tookscan.core.annotation.security.AccountID;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.order.application.usecase.EstimateUserOrderPriceUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderCouponDetailUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadUserOrderDeliveryUseCase;
@@ -47,6 +49,14 @@ public class OrderUserQueryV1Controller {
      * 4.1.9 회원 스캔 가격 계산
      */
     @Operation(summary = "회원 스캔 가격 계산", description = "회원이 스캔 가격을 계산합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_PRICE_POLICY,
+            ErrorCode.NOT_FOUND_COUPON,
+            ErrorCode.NOT_AVAILABLE_COUPON,
+            ErrorCode.USED_COUPON,
+            ErrorCode.INVALID_ARGUMENT,
+            ErrorCode.BAD_REQUEST_PARAMETER
+    })
     @PostMapping(value = "/estimate")
     public ResponseDto<EstimateUserOrderPriceResponseDto> estimateOrderPrice(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -59,6 +69,11 @@ public class OrderUserQueryV1Controller {
      * 4.2.2 회원 주문 내역 조회
      */
     @Operation(summary = "회원 주문 내역 조회", description = "회원이 주문 내역을 조회합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_ACCOUNT,
+            ErrorCode.INVALID_ARGUMENT,
+            ErrorCode.BAD_REQUEST_PARAMETER
+    })
     @GetMapping(value = "/overviews")
     public ResponseDto<ReadUserOrderOverviewResponseDto> getOrderOverview(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -67,7 +82,7 @@ public class OrderUserQueryV1Controller {
             @RequestParam(value = "start-date", required = false) String startDate,
             @RequestParam(value = "end-date", required = false) String endDate,
             @RequestParam(value = "order-status", required = false) EOrderStatus orderStatus,
-            @RequestParam(value = "sort", required = false) String sort,
+            @Parameter(description = "정렬 기준 (order-date, total-amount, document-count)") @RequestParam(value = "sort", required = false) String sort,
             @RequestParam(value = "search", required = false) String search,
             @RequestParam(value = "direction", required = false, defaultValue = "desc") String direction
 
@@ -81,6 +96,12 @@ public class OrderUserQueryV1Controller {
      * 4.2.3 회원 주문 상세 조회
      */
     @Operation(summary = "회원 주문 상세 조회", description = "회원이 주문 상세를 조회합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_ACCOUNT,
+            ErrorCode.NOT_FOUND_ORDER,
+            ErrorCode.NOT_MATCH_ORDER_USER,
+            ErrorCode.ACCESS_DENIED
+    })
     @GetMapping(value = "/{orderId}/details")
     public ResponseDto<ReadUserOrderDetailResponseDto> getUserOrderDetail(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -93,6 +114,13 @@ public class OrderUserQueryV1Controller {
      * 4.2.4 회원 상세 배송 정보 조회
      */
     @Operation(summary = "회원 상세 배송 정보 조회", description = "회원이 상세 배송 정보를 조회합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_ACCOUNT,
+            ErrorCode.NOT_FOUND_ORDER,
+            ErrorCode.NOT_MATCH_ORDER_USER,
+            ErrorCode.INVALID_ORDER_STATUS,
+            ErrorCode.ACCESS_DENIED
+    })
     @GetMapping(value = "/{orderId}/delivery")
     public ResponseDto<ReadUserOrderDeliveryResponseDto> getUserOrderDelivery(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -105,6 +133,12 @@ public class OrderUserQueryV1Controller {
      * 4.2.16 회원 주문 요약 조회
      */
     @Operation(summary = "회원 주문 요약 조회", description = "회원이 주문 요약을 조회합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_ACCOUNT,
+            ErrorCode.NOT_FOUND_ORDER,
+            ErrorCode.NOT_MATCH_ORDER_USER,
+            ErrorCode.ACCESS_DENIED
+    })
     @GetMapping(value = "/summary")
     public ResponseDto<ReadUserOrderSummaryResponseDto> getUserOrderSummary(
             @Parameter(hidden = true) @AccountID UUID accountId,
@@ -117,6 +151,12 @@ public class OrderUserQueryV1Controller {
      * 4.2.19 회원 쿠폰 정보 조회
      */
     @Operation(summary = "회원 쿠폰 정보 조회", description = "회원이 쿠폰 정보를 조회합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_COUPON,
+            ErrorCode.NOT_AVAILABLE_COUPON,
+            ErrorCode.USED_COUPON,
+            ErrorCode.INVALID_ARGUMENT
+    })
     @GetMapping(value = "/coupon/detail")
     public ResponseDto<ReadUserOrderCouponDetailResponseDto> getUserCouponDetail(
             @Parameter(hidden = true) @AccountID UUID accountId,

--- a/src/main/java/com/tookscan/tookscan/payment/presentation/controller/command/PaymentAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/payment/presentation/controller/command/PaymentAdminCommandV1Controller.java
@@ -1,6 +1,8 @@
 package com.tookscan.tookscan.payment.presentation.controller.command;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.payment.application.usecase.RefundPaymentUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,6 +24,23 @@ public class PaymentAdminCommandV1Controller {
      * 7.3.1 (관리자) 환불하기
      */
     @Operation(summary = "관리자 환불하기", description = "관리자가 환불을 진행합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_PAYMENT,
+        ErrorCode.ALREADY_CANCELED_PAYMENT,
+        ErrorCode.NOT_CANCELABLE_PAYMENT,
+        ErrorCode.NOT_CANCELABLE_AMOUNT,
+        ErrorCode.FORBIDDEN_CONSECUTIVE_REQUEST,
+        ErrorCode.PROVIDER_ERROR,
+        ErrorCode.EXTERNAL_SERVER_ERROR,
+        ErrorCode.EXTERNAL_SERVER_TIMEOUT,
+        ErrorCode.REST_CLIENT_ERROR,
+        ErrorCode.UNKNOWN_PAYMENT_ERROR,
+        ErrorCode.FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING,
+        ErrorCode.FAILED_REFUND_PROCESS,
+        ErrorCode.FAILED_METHOD_HANDLING_CANCEL,
+        ErrorCode.FAILED_PARTIAL_REFUND,
+        ErrorCode.COMMON_ERROR
+    })
     @PatchMapping("/{id}/cancel")
     public ResponseDto<Void> refundPayment(
             @PathVariable Long id

--- a/src/main/java/com/tookscan/tookscan/payment/presentation/controller/command/PaymentCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/payment/presentation/controller/command/PaymentCommandV1Controller.java
@@ -1,8 +1,11 @@
 package com.tookscan.tookscan.payment.presentation.controller.command;
 
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.payment.presentation.dto.request.ConfirmPaymentRequestDto;
 import com.tookscan.tookscan.payment.application.usecase.ConfirmPaymentUseCase;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,54 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentCommandV1Controller {
     private final ConfirmPaymentUseCase confirmPaymentUseCase;
 
+    /**
+     * 7.2.1 결제 승인
+     */
+    @Operation(summary = "결제 승인", description = "토스페이먼츠를 통해 결제를 승인합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.NOT_FOUND_PAYMENT_SESSION,
+        ErrorCode.PAYMENT_INCOMPLETE,
+        ErrorCode.ALREADY_PROCESSED_PAYMENT,
+        ErrorCode.PROVIDER_ERROR,
+        ErrorCode.INVALID_API_KEY,
+        ErrorCode.UNAUTHORIZED_KEY,
+        ErrorCode.REJECT_ACCOUNT_PAYMENT,
+        ErrorCode.REJECT_CARD_PAYMENT,
+        ErrorCode.REJECT_CARD_COMPANY,
+        ErrorCode.INVALID_REJECT_CARD,
+        ErrorCode.BELOW_MINIMUM_AMOUNT,
+        ErrorCode.EXCEED_MAX_PAYMENT_AMOUNT,
+        ErrorCode.EXCEED_MAX_CARD_INSTALLMENT_PLAN,
+        ErrorCode.NOT_ALLOWED_POINT_USE,
+        ErrorCode.INVALID_CARD_EXPIRATION,
+        ErrorCode.INVALID_STOPPED_CARD,
+        ErrorCode.EXCEED_MAX_DAILY_PAYMENT_COUNT,
+        ErrorCode.NOT_SUPPORTED_INSTALLMENT_PLAN_CARD_OR_MERCHANT,
+        ErrorCode.INVALID_CARD_INSTALLMENT_PLAN,
+        ErrorCode.NOT_SUPPORTED_MONTHLY_INSTALLMENT_PLAN,
+        ErrorCode.EXCEED_MAX_MONTHLY_PAYMENT_AMOUNT,
+        ErrorCode.NOT_FOUND_TERMINAL_ID,
+        ErrorCode.INVALID_AUTHORIZE_AUTH,
+        ErrorCode.INVALID_CARD_LOST_OR_STOLEN,
+        ErrorCode.RESTRICTED_TRANSFER_ACCOUNT,
+        ErrorCode.INVALID_CARD_NUMBER,
+        ErrorCode.INVALID_UNREGISTERED_SUBMALL,
+        ErrorCode.NOT_REGISTERED_BUSINESS,
+        ErrorCode.EXCEED_MAX_ONE_DAY_WITHDRAW_AMOUNT,
+        ErrorCode.EXCEED_MAX_ONE_TIME_WITHDRAW_AMOUNT,
+        ErrorCode.CARD_PROCESSING_ERROR,
+        ErrorCode.EXCEED_MAX_AMOUNT,
+        ErrorCode.INVALID_ACCOUNT_INFO_RE_REGISTER,
+        ErrorCode.NOT_AVAILABLE_PAYMENT,
+        ErrorCode.UNAPPROVED_ORDER_ID,
+        ErrorCode.EXTERNAL_SERVER_ERROR,
+        ErrorCode.EXTERNAL_SERVER_TIMEOUT,
+        ErrorCode.REST_CLIENT_ERROR,
+        ErrorCode.UNKNOWN_PAYMENT_ERROR,
+        ErrorCode.FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING,
+        ErrorCode.COMMON_ERROR
+    })
     @PostMapping("")
     public ResponseDto<Void> confirmPayment(
             @RequestBody @Valid ConfirmPaymentRequestDto requestDto

--- a/src/main/java/com/tookscan/tookscan/security/presentation/controller/AuthController.java
+++ b/src/main/java/com/tookscan/tookscan/security/presentation/controller/AuthController.java
@@ -37,10 +37,10 @@ import com.tookscan.tookscan.security.presentation.dto.response.IssueAuthenticat
 import com.tookscan.tookscan.security.presentation.dto.response.ReadSerialIdAndProviderResponseDto;
 import com.tookscan.tookscan.security.presentation.dto.response.ReissuePasswordResponseDto;
 import com.tookscan.tookscan.security.presentation.dto.response.ValidationResponseDto;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -55,12 +55,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.util.Optional;
 import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@Hidden
+@Tag(name = "Auth", description = "Auth 관련 API 입니다.")
 @RequestMapping("/v1/auth")
 public class AuthController {
 
@@ -83,6 +82,18 @@ public class AuthController {
     /**
      * 1.2.2 JWT 재발급
      */
+    @Operation(summary = "JWT 재발급", description = "쿠키에 저장된 Refresh Token을 사용하여 새로운 JWT 토큰을 발급합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_COOKIE_ERROR,
+        ErrorCode.EXPIRED_TOKEN_ERROR,
+        ErrorCode.INVALID_TOKEN_ERROR,
+        ErrorCode.TOKEN_MALFORMED_ERROR,
+        ErrorCode.TOKEN_TYPE_ERROR,
+        ErrorCode.TOKEN_UNSUPPORTED_ERROR,
+        ErrorCode.TOKEN_GENERATION_ERROR,
+        ErrorCode.TOKEN_UNKNOWN_ERROR,
+        ErrorCode.NOT_FOUND_ACCOUNT
+    })
     @PostMapping("/reissue/token")
     public void reissueDefaultJsonWebToken(
             HttpServletRequest request,
@@ -99,6 +110,15 @@ public class AuthController {
     /**
      * 2.1.1 휴대폰 인증번호 발송
      */
+    @Operation(summary = "휴대폰 인증번호 발송", description = "휴대폰 번호로 인증번호를 발송합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.TOO_FAST_AUTHENTICATION_CODE_REQUESTS,
+        ErrorCode.TOO_MANY_AUTHENTICATION_CODE_REQUESTS,
+        ErrorCode.EXTERNAL_SERVER_ERROR,
+        ErrorCode.PROVIDER_ERROR
+    })
     @PostMapping("/authentication-code")
     public ResponseDto<IssueAuthenticationCodeResponseDto> issueAuthenticationCode(
             @Valid @RequestBody IssueAuthenticationCodeRequestDto requestDto
@@ -109,6 +129,17 @@ public class AuthController {
     /**
      * 2.1.2 유저 회원가입
      */
+    @Operation(summary = "유저 회원가입", description = "일반 회원가입을 진행하고 JWT 토큰을 발급합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ALREADY_EXIST_ID,
+        ErrorCode.ALREADY_EXIST_PHONE_NUMBER,
+        ErrorCode.NOT_VERIFIED_AUTHENTICATION_CODE,
+        ErrorCode.NOT_FOUND_AUTHENTICATION_CODE,
+        ErrorCode.NOT_MATCH_AUTHENTICATION_CODE,
+        ErrorCode.TOKEN_GENERATION_ERROR
+    })
     @PostMapping("/users/sign-up-default")
     public void signUpDefault(
             @Valid @RequestBody SignUpDefaultRequestDto requestDto,
@@ -123,6 +154,8 @@ public class AuthController {
     /**
      * 관리자 회원가입 (더 이상 사용되지 않음)
      */
+    @Operation(summary = "관리자 회원가입 (사용 중단)", description = "관리자 회원가입 API입니다. 더 이상 사용되지 않습니다.")
+    @ApiErrorCode({})
     @Deprecated
     @PostMapping("/admins/sign-up-default")
 //    public ResponseDto<Void> adminSignUpDefault(
@@ -137,6 +170,24 @@ public class AuthController {
     /**
      * 2.1.3 소셜로그인 유저 회원가입
      */
+    @Operation(summary = "소셜로그인 유저 회원가입", description = "소셜 로그인 후 추가 정보를 입력하여 회원가입을 완료합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_COOKIE_ERROR,
+        ErrorCode.EXPIRED_TOKEN_ERROR,
+        ErrorCode.INVALID_TOKEN_ERROR,
+        ErrorCode.TOKEN_MALFORMED_ERROR,
+        ErrorCode.TOKEN_TYPE_ERROR,
+        ErrorCode.TOKEN_UNSUPPORTED_ERROR,
+        ErrorCode.TOKEN_UNKNOWN_ERROR,
+        ErrorCode.NOT_FOUND_TEMPORARY_ACCOUNT,
+        ErrorCode.ALREADY_EXIST_PHONE_NUMBER,
+        ErrorCode.NOT_VERIFIED_AUTHENTICATION_CODE,
+        ErrorCode.NOT_FOUND_AUTHENTICATION_CODE,
+        ErrorCode.NOT_MATCH_AUTHENTICATION_CODE,
+        ErrorCode.TOKEN_GENERATION_ERROR,
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER
+    })
     @PostMapping("/users/sign-up-oauth")
     public void signUpOauth(
             @Valid @RequestBody SignUpOauthRequestDto requestDto,
@@ -154,6 +205,15 @@ public class AuthController {
     /**
      * 2.1.4 아이디 찾기
      */
+    @Operation(summary = "아이디 찾기", description = "휴대폰 번호를 통해 사용자의 아이디와 로그인 제공자를 조회합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_VERIFIED_AUTHENTICATION_CODE,
+        ErrorCode.NOT_FOUND_AUTHENTICATION_CODE,
+        ErrorCode.NOT_MATCH_AUTHENTICATION_CODE
+    })
     @PostMapping("/verification/serial-id")
     public ResponseDto<ReadSerialIdAndProviderResponseDto> readSerialId(
             @Valid @RequestBody ReadSerialIdAndProviderRequestDto requestDto
@@ -164,6 +224,16 @@ public class AuthController {
     /**
      * 2.1.5 유저 정보 검증
      */
+    @Operation(summary = "유저 정보 검증", description = "사용자의 아이디와 휴대폰 번호를 검증하고 임시 토큰을 발급합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_VERIFIED_AUTHENTICATION_CODE,
+        ErrorCode.NOT_FOUND_AUTHENTICATION_CODE,
+        ErrorCode.NOT_MATCH_AUTHENTICATION_CODE,
+        ErrorCode.TOKEN_GENERATION_ERROR
+    })
     @PostMapping("/verification/user")
     public ResponseDto<Void> verifyUser(
             HttpServletResponse response,
@@ -177,9 +247,16 @@ public class AuthController {
     /**
      * 2.1.6 비밀번호 검증
      */
+    @Operation(summary = "비밀번호 검증", description = "사용자의 현재 비밀번호를 검증합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.FAILURE_LOGIN
+    })
     @PostMapping("/verification/password")
     public ResponseDto<ValidationResponseDto> verifyPassword(
-            @AccountID UUID accountId,
+            @Parameter(hidden = true) @AccountID UUID accountId,
             @Valid @RequestBody VerifyPasswordRequestDto requestDto
     ) {
         return ResponseDto.ok(verifyPasswordUseCase.execute(accountId, requestDto));
@@ -188,6 +265,12 @@ public class AuthController {
     /**
      * 2.2.1 아이디 중복 검사
      */
+    @Operation(summary = "아이디 중복 검사", description = "회원가입 시 아이디의 중복 여부를 확인합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ALREADY_EXIST_ID
+    })
     @GetMapping("/existence/serial-id")
     public ResponseDto<ValidationResponseDto> validateId(
             @RequestParam(name = "serial-id") String serialId
@@ -198,16 +281,13 @@ public class AuthController {
     /**
      * 2.2.2 계정 간단 정보 조회 (더 이상 사용되지 않음)
      */
+    @Operation(summary = "계정 간단 정보 조회 (사용 중단)", description = "계정 간단 정보 조회 API입니다. 더 이상 사용되지 않습니다.")
+    @ApiErrorCode({})
     @Deprecated
     @GetMapping("/briefs")
-    @Operation(summary = "계정 간단 정보 조회", description = "계정 유형(ADMIN, USER)과 이름을 포함한 유저의 기본 정보를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
-    })
 //    public ResponseDto<ReadAccountBriefResponseDto> readAccountBrief(
     public ResponseDto<String> readAccountBrief(
-            @AccountID UUID accountId
+            @Parameter(hidden = true) @AccountID UUID accountId
     ) {
         return ResponseDto.ok("계정 간단 정보 조회는 더 이상 사용되지 않습니다.");
     }
@@ -215,6 +295,15 @@ public class AuthController {
     /**
      * 2.2.3 휴대폰 번호 중복 검사
      */
+    @Operation(summary = "휴대폰 번호 중복 검사", description = "회원가입 시 휴대폰 번호의 중복 여부를 확인합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.ALREADY_EXIST_PHONE_NUMBER,
+        ErrorCode.KAKAO_SIGN_IN_USE,
+        ErrorCode.GOOGLE_SIGN_IN_USE,
+        ErrorCode.NAVER_SIGN_IN_USE
+    })
     @GetMapping("/existence/phone-number")
     public ResponseDto<ValidationResponseDto> validatePhoneNumber(
             @RequestParam(name = "phone-number") String phoneNumber
@@ -225,6 +314,14 @@ public class AuthController {
     /**
      * 2.3.1 휴대폰 인증번호 검증
      */
+    @Operation(summary = "휴대폰 인증번호 검증", description = "발송된 인증번호를 검증하여 인증을 완료합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_AUTHENTICATION_CODE,
+        ErrorCode.NOT_MATCH_AUTHENTICATION_CODE,
+        ErrorCode.EXCEED_MAX_AUTH_COUNT
+    })
     @PatchMapping("/authentication-code")
     public ResponseDto<Void> validateAuthenticationCode(
             @Valid @RequestBody ValidateAuthenticationCodeRequestDto requestDto
@@ -236,6 +333,17 @@ public class AuthController {
     /**
      * 2.3.2 임시 비밀번호 발급
      */
+    @Operation(summary = "임시 비밀번호 발급", description = "사용자 검증 후 임시 비밀번호를 발급합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.NOT_VERIFIED_AUTHENTICATION_CODE,
+        ErrorCode.NOT_FOUND_AUTHENTICATION_CODE,
+        ErrorCode.NOT_MATCH_AUTHENTICATION_CODE,
+        ErrorCode.EXTERNAL_SERVER_ERROR,
+        ErrorCode.PROVIDER_ERROR
+    })
     @PatchMapping("/reissue/password")
     public ResponseDto<ReissuePasswordResponseDto> reissuePassword(
             @Valid @RequestBody ReissuePasswordRequestDto requestDto
@@ -246,9 +354,16 @@ public class AuthController {
     /**
      * 2.3.3 비밀번호 변경
      */
+    @Operation(summary = "비밀번호 변경", description = "사용자의 비밀번호를 변경합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.FAILURE_LOGIN
+    })
     @PatchMapping("/password")
     public ResponseDto<Void> changePassword(
-            @AccountID UUID accountId,
+            @Parameter(hidden = true) @AccountID UUID accountId,
             @Valid @RequestBody ChangePasswordRequestDto requestDto
     ) {
         changePasswordUseCase.execute(accountId, requestDto);
@@ -258,9 +373,16 @@ public class AuthController {
     /**
      * 2.5.1 회원 탈퇴
      */
+    @Operation(summary = "회원 탈퇴", description = "사용자 계정을 삭제합니다.")
+    @ApiErrorCode({
+        ErrorCode.INVALID_ARGUMENT,
+        ErrorCode.BAD_REQUEST_PARAMETER,
+        ErrorCode.NOT_FOUND_ACCOUNT,
+        ErrorCode.FAILURE_LOGIN
+    })
     @DeleteMapping("")
     public ResponseDto<Void> deleteAccount(
-            @AccountID UUID accountId,
+            @Parameter(hidden = true) @AccountID UUID accountId,
             @RequestBody DeleteAccountRequestDto requestDto
     ) {
         deleteAccountUseCase.execute(accountId, requestDto);


### PR DESCRIPTION
## Related issue 🛠
closed #552

어떤 변경사항이 있었나요?
- [x] 📃 Docs: Documentation writing and editing (README.md, etc.)

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
Swagger API 문서에 에러코드 자동 문서화 시스템을 구현했습니다.

### 주요 작업 내용:
1. **어노테이션 기반 에러코드 문서화**
   - `@ApiErrorCode` 어노테이션 추가: 특정 ErrorCode 배열 지정
   - `@ApiErrorExceptions` 어노테이션 추가: 일반적인 예외 클래스 지정

2. **Swagger 커스터마이저 구현**
   - `ErrorCodeCustomizer` 클래스 구현으로 자동 에러 응답 예시 생성
   - 일반적인 예외와 ErrorCode 매핑 테이블 구축
   - 표준 에러 응답 구조 자동 생성

3. **컨트롤러 에러 문서화 적용**
   - `AccountAdminCommandV1Controller`: 그룹/유저 관리 API 에러 문서화
   - `AccountAdminQueryV1Controller`: 유저 조회 API 에러 문서화  
   - `MailCommandV1Controller`: 테스트 메일 발송 API 에러 문서화
   - `MailQueryV1Controller`: 메일 상태 조회 API 에러 문서화
   - `NoticeAdminCommandV1Controller`: 공지사항 관리 API 에러 문서화
   - `NoticeAdminQueryV1Controller`: 공지사항 조회 API 에러 문서화

4. **SwaggerConfig 개선**
   - 모든 API 그룹에 ErrorCodeCustomizer 적용
   - 그룹별 에러 문서화 지원

### 기술적 특징:
- 어노테이션 기반으로 선언적 문서화 방식 채택
- GlobalExceptionHandler 로직과 일치하는 예외-에러코드 매핑
- Swagger UI에서 에러 코드별 상세 응답 예시 제공
- 각 API별 발생 가능한 에러 상황 명확히 문서화

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 모든 Controller에 `@ApiErrorCode` 어노테이션이 적절히 적용되어 있는지 확인해주세요
- Swagger UI에서 각 API의 에러 응답 예시가 정상적으로 표시되는지 테스트해주세요
- 추가 적용이 필요한 Controller가 있다면 알려주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 모든 주요 API 컨트롤러에 OpenAPI(Swagger) 관련 어노테이션이 추가되어, 각 엔드포인트별로 동작 요약, 설명, 예상 오류 코드가 명확하게 문서화됩니다.
  * 새로운 커스텀 어노테이션(`@ApiErrorCode`, `@ApiErrorExceptions`)이 도입되어, API 오류 응답 예시가 Swagger UI에 자동으로 표시됩니다.
  * 일부 파라미터 타입이 enum 등으로 개선되어 API 명세의 타입 안정성이 향상되었습니다.
  * 인증 관련 API에 상세 태그 및 설명이 추가되고, 숨겨진 파라미터가 명확히 표시됩니다.

* **스타일**
  * 기존 코드 로직에는 영향이 없으며, 오직 문서화 및 메타데이터 추가에 국한된 변경입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->