### PR TITLE
✨ Feature - 관리자 PDF 삭제 API 구현

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/exception/error/ErrorCode.java
+++ b/src/main/java/com/tookscan/tookscan/core/exception/error/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
     NOT_UPDATABLE_ORDER(40052, HttpStatus.BAD_REQUEST, "주문 상태가 변경되어 더 이상 수정할 수 없습니다."),
     NOT_RECOVERY_IN_PROGRESS(40053, HttpStatus.BAD_REQUEST, "주문 상태가 복원 작업이 아닙니다."),
     NOT_PAYMENT_COMPLETED(40054, HttpStatus.BAD_REQUEST, "주문 상태가 결제 완료가 아닙니다."),
+    DUPLICATE_DOCUMENT_NAME(40055, HttpStatus.BAD_REQUEST, "이미 존재하는 문서 이름입니다."),
 
     // SIGN UP Error
     ALREADY_EXIST_ID(40200, HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),

--- a/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
@@ -7,7 +7,6 @@ import com.tookscan.tookscan.core.dto.PdfFileDto;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Document;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -15,7 +14,6 @@ import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.multipart.MultipartFile;
 
 @Configuration
 @RequiredArgsConstructor
@@ -85,7 +83,7 @@ public class S3Util {
             throw new CommonException(ErrorCode.NOT_FOUND_PDF_FILE);
         }
         String finalKey =
-                PDF_CONTENT_PREFIX + document.getOrder().getId() + '/' + document.getName() + '_' + document.getId()
+                PDF_CONTENT_PREFIX + document.getOrder().getId() + '/' + document.getName()
                         + ".pdf";
 
         S3Object s3Object = amazonS3Client.getObject(bucketName, finalKey);
@@ -114,7 +112,7 @@ public class S3Util {
     public String uploadPdf(Document document, File file) {
         String finalKey = PDF_CONTENT_PREFIX
                 + document.getOrder().getId() + '/'
-                + document.getName() + '_' + document.getId() + ".pdf";
+                + document.getName() + ".pdf";
         try {
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(file.length());

--- a/src/main/java/com/tookscan/tookscan/order/application/service/DeleteAdminPdfService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/DeleteAdminPdfService.java
@@ -1,0 +1,17 @@
+package com.tookscan.tookscan.order.application.service;
+
+import com.tookscan.tookscan.order.application.usecase.DeleteAdminPdfUseCase;
+import com.tookscan.tookscan.order.repository.PdfRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAdminPdfService implements DeleteAdminPdfUseCase {
+    private final PdfRepository pdfRepository;
+
+    @Override
+    public void execute(Long pdfId) {
+        pdfRepository.deleteByIdOrElseThrow(pdfId);
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/service/EstimateUserOrderPriceService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/EstimateUserOrderPriceService.java
@@ -57,7 +57,8 @@ public class EstimateUserOrderPriceService implements EstimateUserOrderPriceUseC
         Integer deliveryPrice = 0;
         if (requestDto.documents().stream()
                 .anyMatch(document -> document.recoveryOption() != ERecoveryOption.DISCARD)) {
-            deliveryPrice = pricePolicy.getDeliveryPrice();
+            deliveryPrice =
+                    requestDto.deliveryPrice() != null ? requestDto.deliveryPrice() : pricePolicy.getDeliveryPrice();
         }
         Delivery delivery = deliveryService.createDelivery(
                 "",
@@ -91,6 +92,9 @@ public class EstimateUserOrderPriceService implements EstimateUserOrderPriceUseC
                     pricePolicy.getAdditionalPriceForOcr(),
                     doc.isOcrEnabled()
             );
+            if (doc.recoveryOptionPrice() != null) {
+                documentService.updateRecoveryOptionPrice(document, doc.recoveryOptionPrice());
+            }
             if (doc.isChecked()) {
                 order.getDocuments().add(document);
             } else {

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrdersDeliveriesTrackingNumberService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrdersDeliveriesTrackingNumberService.java
@@ -5,6 +5,7 @@ import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.core.utility.ExcelUtils;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrdersDeliveriesTrackingNumberUseCase;
 import com.tookscan.tookscan.order.domain.Order;
+import com.tookscan.tookscan.order.domain.service.DeliveryService;
 import com.tookscan.tookscan.order.repository.OrderRepository;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,8 @@ public class UpdateAdminOrdersDeliveriesTrackingNumberService implements
         UpdateAdminOrdersDeliveriesTrackingNumberUseCase {
 
     private final OrderRepository orderRepository;
+
+    private final DeliveryService deliveryService;
 
     private final ExcelUtils excelUtils;
 
@@ -72,7 +75,7 @@ public class UpdateAdminOrdersDeliveriesTrackingNumberService implements
             String trackingNumber = rowData.trackingNumber();
 
             Order order = orderMap.get(orderNumber);
-            order.getDelivery().updateTrackingNumber(trackingNumber);
+            deliveryService.updateTrackingNumber(order.getDelivery(), trackingNumber);
         }
     }
 

--- a/src/main/java/com/tookscan/tookscan/order/application/usecase/DeleteAdminPdfUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/usecase/DeleteAdminPdfUseCase.java
@@ -1,0 +1,8 @@
+package com.tookscan.tookscan.order.application.usecase;
+
+import com.tookscan.tookscan.core.annotation.bean.UseCase;
+
+@UseCase
+public interface DeleteAdminPdfUseCase {
+    void execute(Long pdfId);
+}

--- a/src/main/java/com/tookscan/tookscan/order/domain/Pdf.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Pdf.java
@@ -35,6 +35,9 @@ public class Pdf extends BaseEntity {
     @Column(name = "is_checked", nullable = false)
     private boolean isChecked;
 
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
     /* -------------------------------------------- */
     /* Many To One Mapping ------------------------ */
     /* -------------------------------------------- */
@@ -51,5 +54,9 @@ public class Pdf extends BaseEntity {
         this.pdfCreatedAt = pdfCreatedAt;
         this.isChecked = isChecked;
         this.document = document;
+    }
+
+    public void updateExpiredAt(LocalDateTime expiredAt) {
+        this.expiredAt = expiredAt;
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/DocumentService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/DocumentService.java
@@ -1,5 +1,7 @@
 package com.tookscan.tookscan.order.domain.service;
 
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Document;
 import com.tookscan.tookscan.order.domain.Order;
 import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
@@ -17,6 +19,11 @@ public class DocumentService {
             Integer additionalPriceForOcr,
             Boolean isOcrEnabled
     ) {
+        // 중복된 이름 검사
+        if (order.getDocuments().stream().anyMatch(doc -> doc.getName().equals(name))) {
+            throw new CommonException(ErrorCode.DUPLICATE_DOCUMENT_NAME, "문서 이름: " + name);
+        }
+
         Document document = Document.builder()
                 .name(name)
                 .pageCount(pageCount)
@@ -41,6 +48,11 @@ public class DocumentService {
             boolean isOcrEnabled,
             Integer additionalPriceForOcr
     ) {
+        // 중복된 이름 검사
+        if (document.getOrder().getDocuments().stream().anyMatch(doc -> doc.getName().equals(name))) {
+            throw new CommonException(ErrorCode.DUPLICATE_DOCUMENT_NAME, "문서 이름: " + name);
+        }
+
         document.updateName(name);
         document.updatePageCount(pageCount);
         document.updateRecoveryOption(recoveryOption);

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/OrderService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/OrderService.java
@@ -41,6 +41,7 @@ public class OrderService {
                 .additionalPriceForOneDayScan(additionalPriceForOneDayScan)
                 .totalAmount(0)
                 .build();
+
         return order;
     }
 

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
@@ -9,6 +9,7 @@ import com.tookscan.tookscan.core.utility.DateTimeUtil;
 import com.tookscan.tookscan.order.application.usecase.CreateAdminOrderCouponUseCase;
 import com.tookscan.tookscan.order.application.usecase.CreateAdminOrderMemoUseCase;
 import com.tookscan.tookscan.order.application.usecase.DeleteAdminDocumentsUseCase;
+import com.tookscan.tookscan.order.application.usecase.DeleteAdminPdfUseCase;
 import com.tookscan.tookscan.order.application.usecase.ExportAdminDeliveriesUseCase;
 import com.tookscan.tookscan.order.application.usecase.SendAdminPdfUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderDeliveryTrackingNumberUseCase;
@@ -80,6 +81,7 @@ public class OrderAdminCommandV1Controller {
     private final UploadAdminDocumentsPdfUseCase uploadAdminDocumentsPdfUseCase;
     private final ValidateAdminPdfUseCase validateAdminPdfUseCase;
     private final UpdateAdminOrdersStatusRecoveryOptionUseCase updateAdminOrdersStatusRecoveryOptionUseCase;
+    private final DeleteAdminPdfUseCase deleteAdminPdfUseCase;
 
     /**
      * 4.1.3 관리자 배송 리스트 내보내기
@@ -381,6 +383,24 @@ public class OrderAdminCommandV1Controller {
             @RequestBody @Valid UpdateAdminOrdersStatusCompanyArrivedRequestDto requestDto
     ) {
         updateAdminOrdersStatusCompanyArrivedUseCase.execute(requestDto);
+        return ResponseDto.ok(null);
+    }
+
+    /**
+     * 관리자 PDF 삭제
+     */
+    @Operation(summary = "관리자 PDF 삭제", description = "관리자가 상품의 PDF를 삭제합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_PDF_FILE,
+            ErrorCode.INVALID_ARGUMENT,
+            ErrorCode.BAD_REQUEST_PARAMETER,
+            ErrorCode.ACCESS_DENIED
+    })
+    @DeleteMapping(value = "/orders/documents/pdf/{pdfId}")
+    public ResponseDto<Void> deleteOrdersDocumentsPdf(
+            @PathVariable Long pdfId
+    ) {
+        deleteAdminPdfUseCase.execute(pdfId);
         return ResponseDto.ok(null);
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderCommonQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderCommonQueryV1Controller.java
@@ -1,0 +1,43 @@
+package com.tookscan.tookscan.order.presentation.controller.query;
+
+import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
+import com.tookscan.tookscan.core.dto.ResponseDto;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.order.application.usecase.EstimateUserOrderPriceUseCase;
+import com.tookscan.tookscan.order.presentation.dto.request.EstimateUserOrderPriceRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.response.EstimateUserOrderPriceResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Order", description = "Order 관련 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/orders")
+public class OrderCommonQueryV1Controller {
+    private final EstimateUserOrderPriceUseCase estimateUserOrderPriceUseCase;
+
+    /**
+     * 4.1.9 스캔 가격 계산
+     */
+    @Operation(summary = "스캔 가격 계산", description = "스캔 가격을 계산합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_PRICE_POLICY,
+            ErrorCode.NOT_FOUND_COUPON,
+            ErrorCode.NOT_AVAILABLE_COUPON,
+            ErrorCode.USED_COUPON,
+            ErrorCode.INVALID_ARGUMENT,
+            ErrorCode.BAD_REQUEST_PARAMETER
+    })
+    @PostMapping(value = "/estimate")
+    public ResponseDto<EstimateUserOrderPriceResponseDto> estimateOrderPrice(
+            @RequestBody @Valid EstimateUserOrderPriceRequestDto requestDto
+    ) {
+        return ResponseDto.ok(estimateUserOrderPriceUseCase.execute(requestDto));
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderUserQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderUserQueryV1Controller.java
@@ -59,7 +59,6 @@ public class OrderUserQueryV1Controller {
     })
     @PostMapping(value = "/estimate")
     public ResponseDto<EstimateUserOrderPriceResponseDto> estimateOrderPrice(
-            @Parameter(hidden = true) @AccountID UUID accountId,
             @RequestBody @Valid EstimateUserOrderPriceRequestDto requestDto
     ) {
         return ResponseDto.ok(estimateUserOrderPriceUseCase.execute(requestDto));

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/EstimateUserOrderPriceRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/EstimateUserOrderPriceRequestDto.java
@@ -23,7 +23,10 @@ public record EstimateUserOrderPriceRequestDto(
 
         @JsonProperty("is_one_day_scan")
         @NotNull(message = "원데이 스캔 여부를 입력해주세요.")
-        Boolean isOneDayScan
+        Boolean isOneDayScan,
+
+        @JsonProperty("delivery_price")
+        Integer deliveryPrice
 ) {
     public record RequestDocument(
 
@@ -46,11 +49,15 @@ public record EstimateUserOrderPriceRequestDto(
             @JsonProperty("recovery_option")
             ERecoveryOption recoveryOption,
 
+            @JsonProperty("recovery_option_price")
+            Integer recoveryOptionPrice,
+
             @JsonProperty("is_ocr_enabled")
             @NotNull(message = "OCR 여부를 입력해주세요.")
             Boolean isOcrEnabled,
 
             @JsonProperty(value = "is_checked")
+            @NotNull(message = "체크 여부를 입력해주세요.")
             Boolean isChecked
     ) {
     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminOrderDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminOrderDetailResponseDto.java
@@ -244,11 +244,12 @@ public class ReadAdminOrderDetailResponseDto extends
         private final Integer totalPrice;
 
         @JsonProperty("pdfs")
-        private final List<String> pdfs;
+        private final List<PdfDto> pdfs;
 
         @Builder
         public DocumentDto(String id, String name, Integer pageCount, Integer pagePrice, ERecoveryOption recoveryOption,
-                           Integer recoveryOptionPrice, Boolean isOcrEnabled, Integer ocrPrice, Integer totalPrice, List<String> pdfs
+                           Integer recoveryOptionPrice, Boolean isOcrEnabled, Integer ocrPrice, Integer totalPrice,
+                           List<PdfDto> pdfs
         ) {
             this.id = id;
             this.name = name;
@@ -276,9 +277,40 @@ public class ReadAdminOrderDetailResponseDto extends
                     .totalPrice(document.getDocumentPrice())
                     .pdfs(pdfs.isEmpty() ? List.of() :
                             pdfs.stream()
-                                    .map(Pdf::getPdfUrl)
+                                    .map(PdfDto::fromEntity)
                                     .toList())
                     .build();
+        }
+
+        @Getter
+        public static class PdfDto extends SelfValidating<PdfDto> {
+
+            @JsonProperty("pdf_url")
+            @NotBlank
+            private final String pdfUrl;
+
+            @JsonProperty("is_expired")
+            private final Boolean isExpired;
+
+            @JsonProperty("expired_at")
+            private final String expiredAt;
+
+            @Builder
+            public PdfDto(String pdfUrl, Boolean isExpired, String expiredAt) {
+                this.pdfUrl = pdfUrl;
+                this.isExpired = isExpired;
+                this.expiredAt = expiredAt;
+                this.validateSelf();
+            }
+
+            public static PdfDto fromEntity(Pdf pdf) {
+                return PdfDto.builder()
+                        .pdfUrl(pdf.getPdfUrl())
+                        .isExpired(pdf.getExpiredAt() != null)
+                        .expiredAt(pdf.getExpiredAt() != null
+                                ? DateTimeUtil.convertLocalDateTimeToDartString(pdf.getExpiredAt()) : null)
+                        .build();
+            }
         }
     }
 

--- a/src/main/java/com/tookscan/tookscan/order/repository/PdfRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/PdfRepository.java
@@ -1,11 +1,12 @@
 package com.tookscan.tookscan.order.repository;
 
 import com.tookscan.tookscan.order.domain.Pdf;
-
 import java.util.List;
 
 public interface PdfRepository {
 
     List<Pdf> findAllByDocumentId(Long documentId);
     void save(Pdf pdf);
+
+    void deleteByIdOrElseThrow(Long pdfId);
 }

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/PdfRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/PdfRepositoryImpl.java
@@ -1,12 +1,13 @@
 package com.tookscan.tookscan.order.repository.impl;
 
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Pdf;
 import com.tookscan.tookscan.order.repository.PdfRepository;
 import com.tookscan.tookscan.order.repository.mysql.PdfJpaRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,5 +22,12 @@ public class PdfRepositoryImpl implements PdfRepository {
     @Override
     public void save(Pdf pdf) {
         pdfJpaRepository.save(pdf);
+    }
+
+    @Override
+    public void deleteByIdOrElseThrow(Long id) {
+        pdfJpaRepository.findById(id)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PDF_FILE, "문서 ID: " + id));
+        pdfJpaRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #567

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)


## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자용 주문 문서 PDF 삭제 API가 추가되었습니다.
  * 주문 가격 견적을 위한 공용 API가 추가되었습니다.
  * PDF 만료일 정보 및 만료 여부가 주문 상세 응답에 포함됩니다.

* **기능 개선**
  * 주문 문서명 중복 시 오류가 발생하도록 검증이 추가되었습니다.
  * 주문 견적 요청 시 배송비 및 문서별 복구 옵션 가격 입력이 가능해졌습니다.
  * PDF 파일명 규칙이 변경되어 S3 저장 시 문서 ID가 제외됩니다.

* **버그 수정**
  * 주문 견적 API에서 불필요한 파라미터가 제거되었습니다.

* **기타**
  * PDF 삭제 관련 내부 로직 및 예외 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->