### PR TITLE
🔨 Fix - 액셀 내보내기 기능 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/exception/error/ErrorCode.java
+++ b/src/main/java/com/tookscan/tookscan/core/exception/error/ErrorCode.java
@@ -88,6 +88,8 @@ public enum ErrorCode {
     NOT_RECOVERY_IN_PROGRESS(40053, HttpStatus.BAD_REQUEST, "주문 상태가 복원 작업이 아닙니다."),
     NOT_PAYMENT_COMPLETED(40054, HttpStatus.BAD_REQUEST, "주문 상태가 결제 완료가 아닙니다."),
     DUPLICATE_DOCUMENT_NAME(40055, HttpStatus.BAD_REQUEST, "이미 존재하는 문서 이름입니다."),
+    NOT_COMAPNY_ARRIVED_ORDER(40056, HttpStatus.BAD_REQUEST, "주문 상태가 업체 도착이 아닙니다."),
+    NOT_POST_WAITING_ORDER(40057, HttpStatus.BAD_REQUEST, "주문 상태가 POST_WAITING이 아닙니다."),
 
     // SIGN UP Error
     ALREADY_EXIST_ID(40200, HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),

--- a/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
@@ -7,10 +7,12 @@ import com.tookscan.tookscan.core.dto.PdfFileDto;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Document;
+import com.tookscan.tookscan.order.domain.Pdf;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -82,9 +84,9 @@ public class S3Util {
         if (!doesObjectExist(document)) {
             throw new CommonException(ErrorCode.NOT_FOUND_PDF_FILE);
         }
-        String finalKey =
-                PDF_CONTENT_PREFIX + document.getOrder().getId() + '/' + document.getName()
-                        + ".pdf";
+        String finalKey = PDF_CONTENT_PREFIX
+                + document.getOrder().getId() + '/' + document.getId() + '/'
+                + document.getName() + ".pdf";
 
         S3Object s3Object = amazonS3Client.getObject(bucketName, finalKey);
 
@@ -110,9 +112,11 @@ public class S3Util {
      * @param file     업로드할 MultipartFile
      */
     public String uploadPdf(Document document, File file) {
+        String fileName = generateUniqueFileName(document);
+
         String finalKey = PDF_CONTENT_PREFIX
-                + document.getOrder().getId() + '/'
-                + document.getName() + ".pdf";
+                + document.getOrder().getId() + '/' + document.getId() + '/'
+                + fileName;
         try {
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(file.length());
@@ -125,6 +129,100 @@ public class S3Util {
             String directUrl = amazonS3Client.getUrl(bucketName, finalKey).toString();
             return directUrl.replace(s3DefaultPath, cloudFrontPath);
         } catch (IOException e) {
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 중복되지 않는 고유한 파일명을 생성하는 메서드
+     *
+     * @param document PDF 파일이 속할 Document 객체
+     * @return 중복되지 않는 파일명 (예: "document.pdf", "document (1).pdf", "document (2).pdf")
+     */
+    private String generateUniqueFileName(Document document) {
+        String baseName = document.getName();
+        String extension = ".pdf";
+
+        // 기존 PDF 파일명들을 수집
+        Set<String> existingFileNames = document.getPdfs().stream()
+                .map(pdf -> {
+                    String url = pdf.getPdfUrl();
+                    // URL에서 파일명 추출 (마지막 '/' 이후의 부분)
+                    int lastSlashIndex = url.lastIndexOf('/');
+                    return lastSlashIndex != -1 ? url.substring(lastSlashIndex + 1) : url;
+                })
+                .collect(java.util.stream.Collectors.toSet());
+
+        String fileName = baseName + extension;
+
+        // 중복되지 않는 파일명이 될 때까지 번호를 증가시킴
+        int counter = 1;
+        while (existingFileNames.contains(fileName)) {
+            fileName = baseName + " (" + counter + ")" + extension;
+            counter++;
+        }
+
+        return fileName;
+    }
+
+    /**
+     * S3에서 객체의 파일명을 변경하고 새로운 URL을 반환하는 메서드 (복사 후 삭제)
+     *
+     * @param document    PDF가 속한 Document 객체
+     * @param oldUrl      기존 PDF URL
+     * @param newFileName 새로운 파일명
+     * @return 변경된 파일의 새로운 URL
+     */
+    public String renameS3ObjectAndGetUrl(Document document, String oldUrl, String newFileName) {
+        String oldKey = PDF_CONTENT_PREFIX
+                + document.getOrder().getId() + '/' + document.getId() + '/'
+                + extractFileNameFromUrl(oldUrl);
+
+        // 새로운 S3 키 생성
+        String newKey = PDF_CONTENT_PREFIX
+                + document.getOrder().getId() + '/' + document.getId() + '/'
+                + newFileName;
+
+        try {
+            // S3에서 객체 복사
+            amazonS3Client.copyObject(bucketName, oldKey, bucketName, newKey);
+
+            // 기존 객체 삭제
+            amazonS3Client.deleteObject(bucketName, oldKey);
+
+            // 새로운 URL 반환
+            String directUrl = amazonS3Client.getUrl(bucketName, newKey).toString();
+            return directUrl.replace(s3DefaultPath, cloudFrontPath);
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * URL에서 파일명을 추출하는 메서드
+     */
+    private String extractFileNameFromUrl(String url) {
+        int lastSlashIndex = url.lastIndexOf('/');
+        return lastSlashIndex != -1 ? url.substring(lastSlashIndex + 1) : url;
+    }
+
+    /**
+     * PDF 파일을 S3에서 삭제하는 메서드
+     *
+     * @param pdf 삭제할 PDF 객체
+     */
+    public void deletePdfFromS3(Pdf pdf) {
+        try {
+            String url = pdf.getPdfUrl();
+            String fileName = extractFileNameFromUrl(url);
+
+            String key = PDF_CONTENT_PREFIX
+                    + pdf.getDocument().getOrder().getId() + '/' + pdf.getDocument().getId() + '/'
+                    + fileName;
+
+            // S3에서 객체 삭제
+            amazonS3Client.deleteObject(bucketName, key);
+        } catch (Exception e) {
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/tookscan/tookscan/order/application/service/DeleteAdminPdfService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/DeleteAdminPdfService.java
@@ -1,17 +1,35 @@
 package com.tookscan.tookscan.order.application.service;
 
+import com.tookscan.tookscan.core.utility.S3Util;
 import com.tookscan.tookscan.order.application.usecase.DeleteAdminPdfUseCase;
+import com.tookscan.tookscan.order.domain.Document;
+import com.tookscan.tookscan.order.domain.Pdf;
+import com.tookscan.tookscan.order.domain.service.PdfService;
 import com.tookscan.tookscan.order.repository.PdfRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class DeleteAdminPdfService implements DeleteAdminPdfUseCase {
     private final PdfRepository pdfRepository;
+    private final S3Util s3Util;
+    private final PdfService pdfService;
 
     @Override
+    @Transactional
     public void execute(Long pdfId) {
+        Pdf pdf = pdfRepository.findByIdOrElseThrow(pdfId);
+        Document document = pdf.getDocument();
+        
+        // S3에서 PDF 파일 삭제
+        s3Util.deletePdfFromS3(pdf);
+        
+        // 데이터베이스에서 PDF 엔티티 삭제
         pdfRepository.deleteByIdOrElseThrow(pdfId);
+        
+        // PDF 삭제 후 해당 Document의 PDF 파일명들을 재정렬
+        pdfService.reorderPdfFileNames(document, s3Util::renameS3ObjectAndGetUrl);
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/application/service/ExportAdminDeliveriesService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ExportAdminDeliveriesService.java
@@ -1,13 +1,13 @@
 package com.tookscan.tookscan.order.application.service;
 
-import com.tookscan.tookscan.core.utility.DateTimeUtil;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.core.utility.ExcelUtils;
-import com.tookscan.tookscan.order.presentation.dto.request.ExportAdminDeliveriesRequestDto;
 import com.tookscan.tookscan.order.application.usecase.ExportAdminDeliveriesUseCase;
 import com.tookscan.tookscan.order.domain.Order;
 import com.tookscan.tookscan.order.domain.type.EOrderStatus;
+import com.tookscan.tookscan.order.presentation.dto.request.ExportAdminDeliveriesRequestDto;
 import com.tookscan.tookscan.order.repository.OrderRepository;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,11 +23,14 @@ public class ExportAdminDeliveriesService implements ExportAdminDeliveriesUseCas
     @Override
     @Transactional
     public byte[] execute(ExportAdminDeliveriesRequestDto requestDto) {
-        LocalDateTime startDate = DateTimeUtil.convertStringToDartDate(requestDto.startDate()).atStartOfDay();
-        LocalDateTime endDate = DateTimeUtil.convertStringToDartDate(requestDto.endDate()).plusDays(1).atStartOfDay();
+        List<Order> orders = orderRepository.findAllByIdOrElseThrow(requestDto.orderIds());
 
-        List<Order> orders = orderRepository.findAllByOrderStatusDateBetweenOrElseThrow(startDate, endDate,
-                EOrderStatus.POST_WAITING);
+        orders.forEach(order -> {
+            if (order.getOrderStatus() != EOrderStatus.POST_WAITING) {
+                throw new CommonException(ErrorCode.NOT_POST_WAITING_ORDER,
+                        "주문 ID: " + order.getId());
+            }
+        });
 
         return excelUtils.writeDeliveries(orders);
     }

--- a/src/main/java/com/tookscan/tookscan/order/domain/Pdf.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Pdf.java
@@ -59,4 +59,8 @@ public class Pdf extends BaseEntity {
     public void updateExpiredAt(LocalDateTime expiredAt) {
         this.expiredAt = expiredAt;
     }
+
+    public void updatePdfUrl(String pdfUrl) {
+        this.pdfUrl = pdfUrl;
+    }
 }

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/PdfService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/PdfService.java
@@ -12,6 +12,64 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PdfService {
 
+    /**
+     * Pdf 엔티티의 URL을 업데이트하는 메서드
+     *
+     * @param pdf    업데이트할 Pdf 객체
+     * @param newUrl 새로운 URL
+     */
+    public void updatePdfUrl(Pdf pdf, String newUrl) {
+        pdf.updatePdfUrl(newUrl);
+    }
+
+    /**
+     * Document에 속한 PDF 파일들의 파일명을 재정렬하는 메서드
+     * PDF 삭제 후 파일명 순서를 다시 정렬합니다.
+     *
+     * @param document    재정렬할 PDF들이 속한 Document 객체
+     * @param s3Renamer   S3에서 파일명을 변경하고 새 URL을 반환하는 함수 (document, oldUrl, newFileName) -> newUrl
+     */
+    public void reorderPdfFileNames(Document document, TriFunction<Document, String, String, String> s3Renamer) {
+        List<Pdf> pdfs = document.getPdfs();
+        if (pdfs.isEmpty()) {
+            return;
+        }
+
+        String baseName = document.getName();
+        String extension = ".pdf";
+
+        for (int i = 0; i < pdfs.size(); i++) {
+            Pdf pdf = pdfs.get(i);
+            String oldUrl = pdf.getPdfUrl();
+            
+            // 새로운 파일명 생성
+            String newFileName = i == 0 ? baseName + extension : baseName + " (" + i + ")" + extension;
+            
+            // 기존 파일명과 새 파일명이 다른 경우에만 URL 업데이트
+            String currentFileName = extractFileNameFromUrl(oldUrl);
+            if (!currentFileName.equals(newFileName)) {
+                String newUrl = s3Renamer.apply(document, oldUrl, newFileName);
+                updatePdfUrl(pdf, newUrl);
+            }
+        }
+    }
+
+    /**
+     * 함수형 인터페이스: 3개의 매개변수를 받는 함수
+     */
+    @FunctionalInterface
+    public interface TriFunction<T, U, V, R> {
+        R apply(T t, U u, V v);
+    }
+
+    /**
+     * URL에서 파일명을 추출하는 메서드
+     */
+    private String extractFileNameFromUrl(String url) {
+        int lastSlashIndex = url.lastIndexOf('/');
+        return lastSlashIndex != -1 ? url.substring(lastSlashIndex + 1) : url;
+    }
+
     public String getPdfUrls(List<Document> documents) {
         if (documents.isEmpty()) {
             throw new CommonException(ErrorCode.NOT_FOUND_DOCUMENT);

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
@@ -5,7 +5,6 @@ import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.annotation.swagger.ApiErrorExceptions;
 import com.tookscan.tookscan.core.dto.ResponseDto;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
-import com.tookscan.tookscan.core.utility.DateTimeUtil;
 import com.tookscan.tookscan.order.application.usecase.CreateAdminOrderCouponUseCase;
 import com.tookscan.tookscan.order.application.usecase.CreateAdminOrderMemoUseCase;
 import com.tookscan.tookscan.order.application.usecase.DeleteAdminDocumentsUseCase;
@@ -90,7 +89,8 @@ public class OrderAdminCommandV1Controller {
     @ApiErrorCode({
         ErrorCode.INVALID_ARGUMENT,
         ErrorCode.BAD_REQUEST_PARAMETER,
-        ErrorCode.ACCESS_DENIED
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.NOT_POST_WAITING_ORDER
     })
     @PostMapping(value = "/deliveries/export")
     public ResponseEntity<Resource> exportDeliveries(
@@ -100,8 +100,7 @@ public class OrderAdminCommandV1Controller {
         byte[] excelBytes = exportAdminDeliveriesUseCase.execute(requestDto);
 
         // 2) 스프링에서 파일 다운로드를 위한 HTTP 응답 헤더 설정
-        String fileName = DateTimeUtil.convertStringToDartDate(requestDto.startDate()) + "~"
-                + DateTimeUtil.convertStringToDartDate(requestDto.endDate()) + "_deliveries.xlsx";
+        String fileName = "orders.xlsx";
         ByteArrayResource resource = new ByteArrayResource(excelBytes);
 
         return ResponseEntity.ok()

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/ExportAdminDeliveriesRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/ExportAdminDeliveriesRequestDto.java
@@ -1,18 +1,12 @@
 package com.tookscan.tookscan.order.presentation.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
 
 public record ExportAdminDeliveriesRequestDto(
-        @JsonProperty("start_date")
-        @NotBlank(message = "시작일을 입력해주세요.")
-        @Pattern(regexp = "\\d{4}\\.\\d{2}\\.\\d{2}")
-        String startDate,
-
-        @JsonProperty("end_date")
-        @NotBlank(message = "종료일을 입력해주세요.")
-        @Pattern(regexp = "\\d{4}\\.\\d{2}\\.\\d{2}")
-        String endDate
+        @JsonProperty("order_ids")
+        @NotEmpty(message = "주문 ID 목록을 입력해주세요.")
+        List<Long> orderIds
 ) {
 }

--- a/src/main/java/com/tookscan/tookscan/order/repository/PdfRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/PdfRepository.java
@@ -9,4 +9,6 @@ public interface PdfRepository {
     void save(Pdf pdf);
 
     void deleteByIdOrElseThrow(Long pdfId);
+
+    Pdf findByIdOrElseThrow(Long pdfId);
 }

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/PdfRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/PdfRepositoryImpl.java
@@ -30,4 +30,10 @@ public class PdfRepositoryImpl implements PdfRepository {
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PDF_FILE, "문서 ID: " + id));
         pdfJpaRepository.deleteById(id);
     }
+
+    @Override
+    public Pdf findByIdOrElseThrow(Long id) {
+        return pdfJpaRepository.findById(id)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PDF_FILE, "문서 ID: " + id));
+    }
 }


### PR DESCRIPTION
## Related issue 🛠
closed #571

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
액셀 내보내기 기능 수정 및 PDF 업로드 파일명 수정 작업을 수행했습니다.

- 관리자 배송 목록 엑셀 내보내기 기능 수정
- PDF 업로드 시 파일명 중복 방지 개선
- S3 파일 업로드 관련 유틸리티 개선
- PDF 삭제 관련 서비스 로직 개선

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
이번 수정사항은 다음과 같습니다:
- 엑셀 내보내기 기능의 안정성 개선
- PDF 파일 업로드 시 파일명 처리 로직 개선
- S3 관련 유틸리티 메서드 개선

특히 파일 업로드와 엑셀 내보내기 기능에 대한 테스트를 중점적으로 확인해 주시기 바랍니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 하나의 문서에 여러 개의 PDF 파일을 업로드하고 각 PDF 파일에 고유한 파일명을 부여할 수 있도록 개선되었습니다.
  * PDF 파일의 이름을 변경하거나 삭제할 수 있는 기능이 추가되었습니다.
  * PDF 파일 삭제 시 S3 저장소에서 파일이 함께 삭제되고, 남은 PDF 파일들의 이름이 순차적으로 재정렬됩니다.

* **버그 수정**
  * 주문 상태가 POST_WAITING이 아닌 경우, 명확한 오류 메시지와 코드로 안내됩니다.

* **변경 사항**
  * 관리자 배송 내보내기 요청 시 날짜 대신 주문 ID 목록을 사용하도록 요청 방식이 변경되었습니다.
  * 관리자 배송 엑셀 파일의 이름이 항상 "orders.xlsx"로 고정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->