### PR TITLE
🔨 Fix - 옵션 변경에 따른 배송여부 및 배송비 수정, PDF 업로드 실패 방지

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderService.java
@@ -30,6 +30,7 @@ public class UpdateAdminOrderService implements UpdateAdminOrderUseCase {
     private final PricePolicyRepository pricePolicyRepository;
     private final OrderRepository orderRepository;
     private final DocumentRepository documentRepository;
+
     private final DocumentService documentService;
     private final OrderService orderService;
     private final DeliveryService deliveryService;
@@ -121,13 +122,18 @@ public class UpdateAdminOrderService implements UpdateAdminOrderUseCase {
         // 삭제 처리 (필요하다면 Order 엔티티에서도 해당 Document를 제거)
         order.getDocuments().removeIf(doc -> toDeleteIds.contains(doc.getId()));
         toDeleteIds.forEach(documentRepository::deleteByIdOrElseThrow);
-        orderService.calculateTotalAmount(order);
+
 
         // 주문 정보 업데이트
         orderService.updateIsOneDayScan(order, requestDto.isOneDayScan());
-
+        if (order.isDelivery()) {
+            deliveryService.updateDeliveryPrice(order.getDelivery(), pricePolicy.getDeliveryPrice());
+        } else {
+            deliveryService.updateDeliveryPrice(order.getDelivery(), 0);
+        }
         deliveryService.updateDeliveryPrice(order.getDelivery(), requestDto.deliveryPrice());
 
+        orderService.calculateTotalAmount(order);
         orderRepository.save(order);
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateUserOrderHistoryService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateUserOrderHistoryService.java
@@ -4,18 +4,27 @@ import com.tookscan.tookscan.account.domain.User;
 import com.tookscan.tookscan.account.repository.UserRepository;
 import com.tookscan.tookscan.address.domain.Address;
 import com.tookscan.tookscan.address.domain.service.AddressService;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.application.usecase.UpdateUserOrderHistoryUseCase;
 import com.tookscan.tookscan.order.domain.Document;
 import com.tookscan.tookscan.order.domain.Order;
 import com.tookscan.tookscan.order.domain.PricePolicy;
+import com.tookscan.tookscan.order.domain.service.DeliveryService;
 import com.tookscan.tookscan.order.domain.service.DocumentService;
 import com.tookscan.tookscan.order.domain.service.OrderService;
 import com.tookscan.tookscan.order.presentation.dto.request.UpdateUserOrderHistoryRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.request.UpdateUserOrderHistoryRequestDto.RequestDocument;
 import com.tookscan.tookscan.order.repository.DocumentRepository;
 import com.tookscan.tookscan.order.repository.OrderRepository;
 import com.tookscan.tookscan.order.repository.PricePolicyRepository;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +41,7 @@ public class UpdateUserOrderHistoryService implements UpdateUserOrderHistoryUseC
     private final OrderService orderService;
     private final DocumentService documentService;
     private final AddressService addressService;
+    private final DeliveryService deliveryService;
 
     @Override
     @Transactional
@@ -44,26 +54,78 @@ public class UpdateUserOrderHistoryService implements UpdateUserOrderHistoryUseC
         // 가격 정책 조회
         PricePolicy pricePolicy = pricePolicyRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqualOrElseThrow(
                 LocalDate.now(), LocalDate.now());
-        // 문서 삭제
-        order.getDocuments().clear();
+        Set<Long> orderDocumentIds = order.getDocuments().stream()
+                .map(Document::getId)
+                .collect(Collectors.toSet());
 
-        // 문서 생성
-        requestDto.documents().forEach(doc -> {
-            Document document = documentService.createDocument(
-                    doc.name(),
-                    doc.pageCount(),
-                    doc.recoveryOption(),
+        // 요청으로 들어온 문서들을 신규 문서(id == null)와 기존 문서(id != null)로 분리
+        List<RequestDocument> newDocuments = requestDto.documents().stream()
+                .filter(doc -> doc.id() == null)
+                .toList();
+
+        List<RequestDocument> existingDocuments = requestDto.documents().stream()
+                .filter(doc -> doc.id() != null)
+                .toList();
+
+        // 기존 문서의 경우, 해당 주문에 속한 문서인지 검증
+        List<Long> existingDocumentIds = existingDocuments.stream()
+                .map(RequestDocument::id)
+                .toList();
+
+        List<Long> invalidDocumentIds = existingDocumentIds.stream()
+                .filter(id -> !orderDocumentIds.contains(id))
+                .toList();
+
+        if (!invalidDocumentIds.isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT,
+                    "해당 주문(Order)에 속하지 않는 문서(Document)가 포함되었습니다: " + invalidDocumentIds);
+        }
+
+        // 기존 문서 업데이트
+        Map<Long, Document> documentMap = documentRepository.findAllByIdsOrElseThrow(existingDocumentIds)
+                .stream()
+                .collect(Collectors.toMap(Document::getId, document -> document));
+
+        existingDocuments.forEach(document -> {
+            documentService.updateDocument(
+                    documentMap.get(document.id()),
+                    document.name(),
+                    document.pageCount(),
+                    document.recoveryOption(),
+                    document.isOcrEnabled(),
+                    pricePolicy.getAdditionalPriceForOcr()
+            );
+
+            documentRepository.save(documentMap.get(document.id()));
+        });
+
+        // 신규 문서 생성
+        newDocuments.forEach(document -> {
+            Document doc = documentService.createDocument(
+                    document.name(),
+                    document.pageCount(),
+                    document.recoveryOption(),
                     order,
                     pricePolicy.getCuttingPrice(),
                     pricePolicy.getDefaultPricePerPage(),
                     pricePolicy.getAdditionalPriceForOcr(),
-                    doc.isOcrEnabled()
+                    document.isOcrEnabled()
             );
-            order.getDocuments().add(document);
-            documentRepository.save(document);
+            documentRepository.save(doc);
         });
 
-        orderService.updateIsOneDayScan(order, requestDto.isOneDayScan());
+        // 삭제 처리: DB에 존재하지만 요청에 포함되지 않은 문서는 삭제
+        // 요청에 포함된 기존 문서의 ID 집합
+        Set<Long> requestExistingIds = new HashSet<>(existingDocumentIds);
+        // 주문에 속한 기존 문서 중 요청에 포함되지 않은 ID 찾기
+        Set<Long> toDeleteIds = orderDocumentIds.stream()
+                .filter(id -> !requestExistingIds.contains(id))
+                .collect(Collectors.toSet());
+        System.out.println("toDeleteIds = " + toDeleteIds);
+        // 삭제 처리 (필요하다면 Order 엔티티에서도 해당 Document를 제거)
+        order.getDocuments().removeIf(doc -> toDeleteIds.contains(doc.getId()));
+        toDeleteIds.forEach(documentRepository::deleteByIdOrElseThrow);
+
         if (requestDto.address() != null) {
             Address address = addressService.createAddress(
                     requestDto.address().addressName(),
@@ -80,6 +142,16 @@ public class UpdateUserOrderHistoryService implements UpdateUserOrderHistoryUseC
             order.getDelivery().updateRequest(requestDto.deliveryRequest());
         }
 
+        // 주문 정보 업데이트
+        orderService.updateIsOneDayScan(order, requestDto.isOneDayScan());
+
+        if (order.isDelivery()) {
+            deliveryService.updateDeliveryPrice(order.getDelivery(), pricePolicy.getDeliveryPrice());
+        } else {
+            deliveryService.updateDeliveryPrice(order.getDelivery(), 0);
+        }
+
+        orderService.calculateTotalAmount(order);
         orderRepository.save(order);
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/domain/Document.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Document.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -77,7 +78,7 @@ public class Document extends BaseEntity {
     /* One to Many Column ------------------------- */
     /* -------------------------------------------- */
     @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Pdf> pdfs;
+    private List<Pdf> pdfs = new ArrayList<>();
 
     /* -------------------------------------------- */
     /* Methods ------------------------------------ */

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/OrderService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/OrderService.java
@@ -154,10 +154,6 @@ public class OrderService {
         }
     }
 
-    public void updateScanTermsAgreed(Order order) {
-        order.updateScanTermsAgreed();
-    }
-
     public void updatePaymentExpirationDate(Order order) {
         order.updatePaymentExpirationDate(LocalDateTime.now().plusDays(PAYMENT_EXPIRATION_PERIOD));
     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/UpdateUserOrderHistoryRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/UpdateUserOrderHistoryRequestDto.java
@@ -32,6 +32,10 @@ public record UpdateUserOrderHistoryRequestDto(
 ) {
     public record RequestDocument(
 
+            @JsonProperty("id")
+            @NotNull(message = "문서 ID를 입력해주세요.")
+            Long id,
+
             @JsonProperty("name")
             @NotBlank(message = "문서 이름을 입력해주세요.")
             @ByteSize(min = 2, max = 100, message = "문서 이름의 크기는 최소 2바이트 ~ 최대 100바이트 입니다.")

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderDetailResponseDto.java
@@ -111,6 +111,10 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
 
     @Getter
     public static class DocumentInfoDto extends SelfValidating<DocumentInfoDto> {
+
+        @JsonProperty("id")
+        private final String id;
+
         @JsonProperty("name")
         @NotNull
         private final String name;
@@ -156,7 +160,9 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
                                Integer recoveryPrice,
                                Integer oneDayScanPrice,
                                Integer cuttingPrice,
-                               Integer ocrPrice) {
+                               Integer ocrPrice,
+                               String id
+        ) {
             this.name = name;
             this.pageCount = pageCount;
             this.documentPrice = documentPrice;
@@ -166,6 +172,7 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
             this.oneDayScanPrice = oneDayScanPrice;
             this.cuttingPrice = cuttingPrice;
             this.ocrPrice = ocrPrice;
+            this.id = id;
             this.validateSelf();
         }
 
@@ -180,6 +187,7 @@ public class ReadUserOrderDetailResponseDto extends SelfValidating<ReadUserOrder
                     .oneDayScanPrice(document.getOneDayScanPrice())
                     .ocrPrice(document.getOcrPrice())
                     .cuttingPrice(document.getCuttingPrice())
+                    .id(document.getId().toString())
                     .build();
         }
     }


### PR DESCRIPTION
## Related issue 🛠
closed #582

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
주문 내역 수정 API와 관리자 주문 수정 API에서 발생하는 버그들을 수정했습니다.

### 주요 수정 사항
1. **Document 엔티티의 pdfs 필드 초기화**
   - `List<Pdf> pdfs = new ArrayList<>()` 로 초기화하여 NullPointerException 방지
   - PDF 업로드 시 발생하는 실패 상황 해결

2. **주문 수정 시 배송비 계산 로직 개선**
   - 배송 여부에 따른 배송비 자동 계산
   - 배송이 없는 경우 배송비 0원으로 설정
   - 배송이 있는 경우 정책에 따른 배송비 적용

3. **주문 내역 수정 API 전면 개선**
   - 기존 문서와 신규 문서 분리 처리
   - 기존 문서 업데이트 로직 구현
   - 요청에 포함되지 않은 문서 삭제 처리
   - 문서 소유권 검증 로직 추가

4. **관리자 주문 수정 시 총액 계산 순서 최적화**
   - 배송비 설정 후 총액 계산하도록 순서 변경

### 변경 파일
- `Document.java`: pdfs 필드 초기화
- `UpdateUserOrderHistoryService.java`: 주문 내역 수정 로직 전면 개선
- `UpdateAdminOrderService.java`: 배송비 계산 로직 개선
- `UpdateUserOrderHistoryRequestDto.java`: 문서 ID 필드 추가
- `ReadUserOrderDetailResponseDto.java`: 응답 DTO에 문서 ID 포함
- `OrderService.java`: 사용하지 않는 메서드 제거

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- Document 엔티티의 pdfs 필드 초기화로 PDF 업로드 실패 이슈가 해결되었는지 확인해주세요
- 주문 수정 시 배송비가 올바르게 계산되는지 테스트해주세요
- 주문 내역 수정 API에서 기존 문서 업데이트와 신규 문서 생성이 정상적으로 동작하는지 확인해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주문 상세 조회 시 각 문서에 대한 ID 정보가 응답에 포함됩니다.
  * 사용자 주문 이력 수정 요청 시 각 문서에 대해 ID 필드가 요구됩니다.

* **버그 수정**
  * 문서 목록이 항상 빈 리스트로 초기화되어, 문서 관련 처리 시 NullPointerException이 발생하지 않도록 개선되었습니다.

* **리팩터링**
  * 사용자 주문 이력 수정 시 문서 추가, 수정, 삭제 로직이 세분화되어 처리 정확성이 향상되었습니다.
  * 배송비 및 총 금액 계산 로직이 보다 명확하게 재배치되었습니다.

* **기타**
  * 더 이상 사용되지 않는 내부 동의 상태 갱신 메서드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->