### PR TITLE
✨ Feature - 관리자 결제 취소 API 구현

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/listener/KakaoMessageListener.java
+++ b/src/main/java/com/tookscan/tookscan/core/listener/KakaoMessageListener.java
@@ -123,4 +123,23 @@ public class KakaoMessageListener {
             log.error("배송 안내 메시지 발송 실패", e);
         }
     }
+
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = {RequestScanMessageEvent.class})
+    public void handleCancelPaymentMessageEvent(RequestScanMessageEvent event) {
+        log.info(
+                "\n----------------------------------\n[ 결제 취소 메시지 이벤트 처리 ]\n{}\n{}\n----------------------------------",
+                "주문명: " + event.getOrderName(),
+                "주문번호: " + event.getOrderNumber()
+        );
+
+        try {
+            kakaoMessageUtil.sendCancelPaymentMessage(
+                    event.getOrderName(),
+                    event.getPhoneNumber()
+            );
+        } catch (Exception e) {
+            log.error("결제 취소 메시지 발송 실패", e);
+        }
+    }
 }

--- a/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
@@ -33,6 +33,9 @@ public class KakaoMessageUtil {
     @Value("${solapi.template-id.announce-delivery}")
     private String templateIdAnnounceDelivery;
 
+    @Value("${solapi.template-id.cancel-payment}")
+    private String templateIdCancelPayment;
+
     @Value("${solapi.sender}")
     private String sender;
 
@@ -176,6 +179,26 @@ public class KakaoMessageUtil {
 
         kakaoOption.setPfId(pfId);
         kakaoOption.setTemplateId(templateIdAnnounceDelivery);
+
+        Message message = new Message();
+        message.setTo(to);
+        message.setFrom(sender);
+        message.setKakaoOptions(kakaoOption);
+
+        this.messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+
+    public void sendCancelPaymentMessage(String orderName, String to) {
+
+        KakaoOption kakaoOption = new KakaoOption();
+
+        HashMap<String, String> variables = new HashMap<>();
+        variables.put("#{orderName}", orderName);
+
+        kakaoOption.setVariables(variables);
+
+        kakaoOption.setPfId(pfId);
+        kakaoOption.setTemplateId(templateIdCancelPayment);
 
         Message message = new Message();
         message.setTo(to);

--- a/src/main/java/com/tookscan/tookscan/message/domain/event/CancelPaymentMessageEvent.java
+++ b/src/main/java/com/tookscan/tookscan/message/domain/event/CancelPaymentMessageEvent.java
@@ -1,0 +1,19 @@
+package com.tookscan.tookscan.message.domain.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CancelPaymentMessageEvent {
+
+    private final String orderName;
+    private final String phoneNumber;
+
+    public static CancelPaymentMessageEvent of(String orderName, String phoneNumber) {
+        return CancelPaymentMessageEvent.builder()
+                .orderName(orderName)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedService.java
@@ -1,0 +1,46 @@
+package com.tookscan.tookscan.order.application.service;
+
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
+import com.tookscan.tookscan.message.domain.event.CancelPaymentMessageEvent;
+import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase;
+import com.tookscan.tookscan.order.domain.Order;
+import com.tookscan.tookscan.order.domain.type.EOrderStatus;
+import com.tookscan.tookscan.order.repository.OrderRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedService implements UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase {
+
+    private final OrderRepository orderRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
+    public void execute(Long orderId) {
+        // 주문 조회
+        Order order = orderRepository.findByIdOrElseThrow(orderId);
+
+        // 주문 상태가 결제 대기 중인지 확인
+        if (!order.getOrderStatus().equals(EOrderStatus.PAYMENT_WAITING)) {
+            throw new CommonException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+
+        // 주문 상태를 회사 도착으로 업데이트
+        order.updateOrderStatus(EOrderStatus.COMPANY_ARRIVED);
+
+        // 주문 저장
+        orderRepository.save(order);
+
+        // 알림톡 발송
+        applicationEventPublisher.publishEvent(
+                CancelPaymentMessageEvent.of(
+                        order.getDocumentsDescription(),
+                        order.getDelivery().getPhoneNumber()
+                )
+        );
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/usecase/UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/usecase/UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase.java
@@ -1,0 +1,9 @@
+package com.tookscan.tookscan.order.application.usecase;
+
+import com.tookscan.tookscan.core.annotation.bean.UseCase;
+
+@UseCase
+public interface UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase {
+
+    void execute(Long orderId);
+}

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
@@ -13,6 +13,7 @@ import com.tookscan.tookscan.order.application.usecase.ExportAdminDeliveriesUseC
 import com.tookscan.tookscan.order.application.usecase.SendAdminPdfUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderDeliveryTrackingNumberUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderDeliveryUseCase;
+import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderStatusPaymentWaitingUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrderUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrdersDeliveriesTrackingNumberUseCase;
@@ -82,6 +83,7 @@ public class OrderAdminCommandV1Controller {
     private final ValidateAdminPdfUseCase validateAdminPdfUseCase;
     private final UpdateAdminOrdersStatusRecoveryOptionUseCase updateAdminOrdersStatusRecoveryOptionUseCase;
     private final DeleteAdminPdfUseCase deleteAdminPdfUseCase;
+    private final UpdateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase updateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase;
 
     /**
      * 4.1.3 관리자 배송 리스트 내보내기
@@ -402,6 +404,23 @@ public class OrderAdminCommandV1Controller {
             @PathVariable Long pdfId
     ) {
         deleteAdminPdfUseCase.execute(pdfId);
+        return ResponseDto.ok(null);
+    }
+
+    /**
+     * 관리자 결제 취소
+     */
+    @Operation(summary = "관리자 결제 취소", description = "관리자가 주문의 결제를 취소합니다.")
+    @ApiErrorCode({
+        ErrorCode.NOT_FOUND_ORDER,
+        ErrorCode.INVALID_ORDER_STATUS,
+        ErrorCode.ACCESS_DENIED
+    })
+    @PatchMapping(value = "/orders/{id}/cancel-payment")
+    public ResponseDto<Void> updateOrderStatusPaymentWaitingToCompanyArrived(
+            @PathVariable Long id
+    ) {
+        updateAdminOrderStatusPaymentWaitingToCompanyArrivedUseCase.execute(id);
         return ResponseDto.ok(null);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -194,6 +194,7 @@ solapi:
     request-scan: ${SOLAPI_TEMPLATE_REQUEST_SCAN}
     announce-scan-finish: ${SOLAPI_TEMPLATE_ANNOUNCE_SCAN_FINISH}
     announce-delivery: ${SOLAPI_TEMPLATE_ANNOUNCE_DELIVERY}
+    cancel-payment: ${SOLAPI_TEMPLATE_CANCEL_PAYMENT}
   sender: ${SOLAPI_SENDER}
   tip-url: ${SOLAPI_TIP_URL}
   payment-url: ${SOLAPI_PAYMENT_URL}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #602 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 관리자 결제 취소 API 구현

관리자 결제 취소 API를 구현했습니다.
해당 기능은 결제 대기 상태의 주문에서만 작동 가능하며, 
결제 대기 -> 업체 도착으로 상태를 변경하고
고객에게 알림톡을 전송합니다. 

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 주문 결제 상태를 "결제 대기"에서 "회사 도착"으로 변경하고 결제 취소를 처리할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
  * 결제 취소 시 카카오 알림톡을 통해 결제 취소 메시지가 발송됩니다.

* **환경설정**
  * 결제 취소 메시지 템플릿 ID를 위한 설정 값이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->