### PR TITLE
🔨 Fix -알림톡 결제하기 url에 쿼리 변수 추가 / 결제하기와 주문상세를 orderId 기반으로 변경

### DIFF
--- a/http/order/OrderControllerHttpRequest.http
+++ b/http/order/OrderControllerHttpRequest.http
@@ -62,7 +62,7 @@ GET {{host_url}}/v1/admins/orders/732163380529619446/details
 
 ### 관리자 pdf 업로드
 //@no-log
-POST {{host_url}}/v1/admins/documents/732163380542202321/pdfs
+POST {{host_url}}/v1/admins/documents/738116895722729202/pdfs
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary

--- a/src/main/java/com/tookscan/tookscan/core/listener/KakaoMessageListener.java
+++ b/src/main/java/com/tookscan/tookscan/core/listener/KakaoMessageListener.java
@@ -3,6 +3,7 @@ package com.tookscan.tookscan.core.listener;
 import com.tookscan.tookscan.core.utility.KakaoMessageUtil;
 import com.tookscan.tookscan.message.domain.event.AnnounceDeliveryMessageEvent;
 import com.tookscan.tookscan.message.domain.event.AnnounceScanFinishMessageEvent;
+import com.tookscan.tookscan.message.domain.event.CancelPaymentMessageEvent;
 import com.tookscan.tookscan.message.domain.event.CreateOrderMessageEvent;
 import com.tookscan.tookscan.message.domain.event.RequestPaymentMessageEvent;
 import com.tookscan.tookscan.message.domain.event.RequestScanMessageEvent;
@@ -26,13 +27,13 @@ public class KakaoMessageListener {
         log.info(
                 "\n----------------------------------\n[ 스캔 요청 메시지 이벤트 처리 ]\n{}\n{}\n----------------------------------",
                 "주문명: " + event.getOrderName(),
-                "주문번호: " + event.getOrderNumber()
+                "주문Id: " + event.getOrderId()
         );
 
         try {
             kakaoMessageUtil.sendRequestScanMessage(
                     event.getOrderName(),
-                    event.getOrderNumber(),
+                    event.getOrderId(),
                     event.getUserEmail(),
                     event.getPhoneNumber()
             );
@@ -95,6 +96,8 @@ public class KakaoMessageListener {
             kakaoMessageUtil.sendRequestPaymentMessage(
                     event.getOrderName(),
                     event.getOrderPrice(),
+                    event.getOrderId(),
+                    event.getPaymentKey(),
                     event.getOrderNumber(),
                     event.getPhoneNumber()
             );
@@ -108,7 +111,7 @@ public class KakaoMessageListener {
     public void handleAnnounceDeliveryMessageEvent(AnnounceDeliveryMessageEvent event) {
         log.info(
                 "\n----------------------------------\n[ 배송 안내 메시지 이벤트 처리 ]\n{}\n{}\n----------------------------------",
-                "주문명: " + event.getOrderName(),
+                "배송 ID: " + event.getDeliveryId(),
                 "운송장번호: " + event.getTrackingNumber()
         );
 
@@ -116,7 +119,7 @@ public class KakaoMessageListener {
             kakaoMessageUtil.sendAnnounceDeliveryMessage(
                     event.getOrderName(),
                     event.getTrackingNumber(),
-                    event.getOrderNumber(),
+                    event.getDeliveryId(),
                     event.getPhoneNumber()
             );
         } catch (Exception e) {
@@ -125,12 +128,11 @@ public class KakaoMessageListener {
     }
 
     @Async("notificationTaskExecutor")
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = {RequestScanMessageEvent.class})
-    public void handleCancelPaymentMessageEvent(RequestScanMessageEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = {CancelPaymentMessageEvent.class})
+    public void handleCancelPaymentMessageEvent(CancelPaymentMessageEvent event) {
         log.info(
                 "\n----------------------------------\n[ 결제 취소 메시지 이벤트 처리 ]\n{}\n{}\n----------------------------------",
-                "주문명: " + event.getOrderName(),
-                "주문번호: " + event.getOrderNumber()
+                "주문명: " + event.getOrderName()
         );
 
         try {

--- a/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
@@ -95,7 +95,7 @@ public class KakaoMessageUtil {
 
     }
 
-    public void sendRequestPaymentMessage(String orderName, Integer orderPrice, String orderNumber, String to) {
+    public void sendRequestPaymentMessage(String orderName, Integer orderPrice, Long orderId, String paymentKey, String orderNumber, String to) {
 
         KakaoOption kakaoOption = new KakaoOption();
 
@@ -103,8 +103,8 @@ public class KakaoMessageUtil {
 
         variables.put("#{orderName}", orderName);
         variables.put("#{orderPrice}", String.valueOf(orderPrice));
-        variables.put("#{paymentUrl}", paymentUrl + orderNumber);
-        variables.put("#{orderDetailUrl}", orderDetailUrl + orderNumber);
+        variables.put("#{paymentUrl}", paymentUrl + orderId + "?order_number=" + orderNumber + "&payment_key=" + paymentKey + "&amount=" + orderPrice);
+        variables.put("#{orderDetailUrl}", orderDetailUrl + orderId);
 
         kakaoOption.setVariables(variables);
 
@@ -120,7 +120,7 @@ public class KakaoMessageUtil {
 
     }
 
-    public void sendRequestScanMessage(String orderName, String orderNumber, String userEmail, String to) {
+    public void sendRequestScanMessage(String orderName, Long orderId, String userEmail, String to) {
 
         KakaoOption kakaoOption = new KakaoOption();
 
@@ -128,7 +128,7 @@ public class KakaoMessageUtil {
 
         variables.put("#{orderName}", orderName);
         variables.put("#{userEmail}", userEmail);
-        variables.put("#{orderDetailUrl}", orderDetailUrl + orderNumber);
+        variables.put("#{orderDetailUrl}", orderDetailUrl + orderId);
 
         kakaoOption.setVariables(variables);
 
@@ -163,16 +163,16 @@ public class KakaoMessageUtil {
         this.messageService.sendOne(new SingleMessageSendingRequest(message));
     }
 
-    public void sendAnnounceDeliveryMessage(String orderName, String orderWaybill, String orderNumber, String to) {
+    public void sendAnnounceDeliveryMessage(String orderName, String orderWaybill, Long deliveryId, String to) {
 
         KakaoOption kakaoOption = new KakaoOption();
 
-        String waybillUrl = orderWaybillUrl.replace("{orderNumber}", orderNumber);
+        String waybillUrl = orderWaybillUrl.replace("{deliveryId}", String.valueOf(deliveryId));
 
         HashMap<String, String> variables = new HashMap<>();
         variables.put("#{orderName}", orderName);
         variables.put("#{orderWaybill}", orderWaybill);
-        variables.put("#{orderDetailUrl}", orderDetailUrl + orderNumber);
+        variables.put("#{orderDetailUrl}", orderDetailUrl + deliveryId);
         variables.put("#{orderWaybillUrl}", waybillUrl);
 
         kakaoOption.setVariables(variables);

--- a/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
@@ -103,7 +103,7 @@ public class KakaoMessageUtil {
 
         variables.put("#{orderName}", orderName);
         variables.put("#{orderPrice}", String.valueOf(orderPrice));
-        variables.put("#{paymentUrl}", paymentUrl + orderId + "?order_number=" + orderNumber + "&payment_key=" + paymentKey + "&amount=" + orderPrice);
+        variables.put("#{paymentUrl}", paymentUrl + orderId + "?order-number=" + orderNumber + "&payment-key=" + paymentKey + "&amount=" + orderPrice);
         variables.put("#{orderDetailUrl}", orderDetailUrl + orderId);
 
         kakaoOption.setVariables(variables);

--- a/src/main/java/com/tookscan/tookscan/message/domain/event/AnnounceDeliveryMessageEvent.java
+++ b/src/main/java/com/tookscan/tookscan/message/domain/event/AnnounceDeliveryMessageEvent.java
@@ -9,14 +9,14 @@ public class AnnounceDeliveryMessageEvent {
 
     private final String orderName;
     private final String trackingNumber;
-    private final String orderNumber;
+    private final Long deliveryId;
     private final String phoneNumber;
 
-    public static AnnounceDeliveryMessageEvent of(String orderName, String trackingNumber, String orderNumber, String phoneNumber) {
+    public static AnnounceDeliveryMessageEvent of(String orderName, String trackingNumber, Long deliveryId, String phoneNumber) {
         return AnnounceDeliveryMessageEvent.builder()
                 .orderName(orderName)
                 .trackingNumber(trackingNumber)
-                .orderNumber(orderNumber)
+                .deliveryId(deliveryId)
                 .phoneNumber(phoneNumber)
                 .build();
     }

--- a/src/main/java/com/tookscan/tookscan/message/domain/event/RequestPaymentMessageEvent.java
+++ b/src/main/java/com/tookscan/tookscan/message/domain/event/RequestPaymentMessageEvent.java
@@ -9,13 +9,17 @@ public class RequestPaymentMessageEvent {
 
     private final String orderName;
     private final Integer orderPrice;
+    private final Long orderId;
+    private final String paymentKey;
     private final String orderNumber;
     private final String phoneNumber;
 
-    public static RequestPaymentMessageEvent of(String orderName, Integer orderPrice, String orderNumber, String phoneNumber) {
+    public static RequestPaymentMessageEvent of(String orderName, Integer orderPrice, Long orderId, String paymentKey, String orderNumber, String phoneNumber) {
         return RequestPaymentMessageEvent.builder()
                 .orderName(orderName)
                 .orderPrice(orderPrice)
+                .orderId(orderId)
+                .paymentKey(paymentKey)
                 .orderNumber(orderNumber)
                 .phoneNumber(phoneNumber)
                 .build();

--- a/src/main/java/com/tookscan/tookscan/message/domain/event/RequestScanMessageEvent.java
+++ b/src/main/java/com/tookscan/tookscan/message/domain/event/RequestScanMessageEvent.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 public class RequestScanMessageEvent {
 
     private final String orderName;
-    private final String orderNumber;
+    private final Long orderId;
     private final String userEmail;
     private final String phoneNumber;
 
-    public static RequestScanMessageEvent of(String orderName, String orderNumber, String userEmail, String phoneNumber) {
+    public static RequestScanMessageEvent of(String orderName, Long orderId, String userEmail, String phoneNumber) {
         return RequestScanMessageEvent.builder()
                 .orderName(orderName)
-                .orderNumber(orderNumber)
+                .orderId(orderId)
                 .userEmail(userEmail)
                 .phoneNumber(phoneNumber)
                 .build();


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #604 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 알림톡 결제하기 url에 쿼리 변수 추가

사용자가 알림톡에서 '결제하기' 버튼 클릭 시, 아래의 Url로 이동합니다. 프엔분들은 해당 Url에 결제 모달을 띄워주시고, 같이 전송되는 orderId와 query variable을 이용해 결제승인 API를 호출해주시면 될 것 같습니다.

https://client.dev.tookscan.com/guest/checkout/{orderId}?order-number={}&amount={}

ex) https://client.dev.tookscan.com/guest/checkout/738078066626290176?order-number=0MFHE2X8W8RFZ&amount=1200


- 알림톡에서의 주문상세 조회를, 로그인을 반드시 해야한다는 요구사항에 의해, 기존에 개발되어있던 '주문상세' 페이지 url로 설정. orderId 기반으로 변경.

이제 알림톡에서 '주문 상세' 버튼을 클릭하면, https://client.dev.tookscan.com/profile/order/{orderId} 로 이동합니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 결제 취소 메시지 발송 기능이 추가되었습니다.

* **버그 수정**
  * 메시지 발송 시 주문번호 대신 주문 ID, 배송 ID, 결제 키 등 더 정확한 식별자를 사용하도록 개선되었습니다.

* **기타**
  * 메시지 이벤트 및 관련 메서드의 파라미터와 URL 구조가 변경되어, 메시지 내 정보가 더욱 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->