### PR TITLE
🔨 Fix - 방문택배 URL을 PC 전용과 모바일 전용 분기 처리

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/KakaoMessageUtil.java
@@ -51,8 +51,11 @@ public class KakaoMessageUtil {
     @Value("${solapi.order-waybill-url}")
     private String orderWaybillUrl;
 
-    @Value("${solapi.user-post-way-1-url}")
-    private String userPostWay1Url;
+    @Value("${solapi.user-post-way-pc-url}")
+    private String userPostWayPcUrl;
+
+    @Value("${solapi.user-post-way-mobile-url}")
+    private String userPostWayMobileUrl;
 
     @Value("${solapi.user-post-way-2-url}")
     private String userPostWay2Url;
@@ -76,7 +79,8 @@ public class KakaoMessageUtil {
         variables.put("#{userName}", userName);
         variables.put("#{userPhone}", userPhone);
         variables.put("#{orderName}", orderName);
-        variables.put("#{userPostWay1}", userPostWay1Url);
+        variables.put("#{userPostWayPc}", userPostWayPcUrl);
+        variables.put("#{userPostWayMobile}", userPostWayMobileUrl);
         variables.put("#{userPostWay2}", userPostWay2Url);
         variables.put("#{postPrice}", postPriceUrl);
         variables.put("#{tipUrl}", tipUrl);

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderDeliveryTrackingNumberService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderDeliveryTrackingNumberService.java
@@ -53,7 +53,7 @@ public class UpdateAdminOrderDeliveryTrackingNumberService implements UpdateAdmi
                 AnnounceDeliveryMessageEvent.of(
                         delivery.getOrder().getDocumentsDescription(),
                         delivery.getTrackingNumber(),
-                        delivery.getOrder().getOrderNumber(),
+                        delivery.getId(),
                         delivery.getPhoneNumber()
                 )
         );

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderStatusPaymentWaitingService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrderStatusPaymentWaitingService.java
@@ -36,6 +36,8 @@ public class UpdateAdminOrderStatusPaymentWaitingService implements UpdateAdminO
                 RequestPaymentMessageEvent.of(
                         order.getDocumentsDescription(),
                         order.getTotalAmount(),
+                        order.getId(),
+                        order.getPayment().getPaymentKey(),
                         order.getOrderNumber(),
                         order.getDelivery().getPhoneNumber()
                 )

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrdersDeliveriesTrackingNumberService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrdersDeliveriesTrackingNumberService.java
@@ -100,7 +100,7 @@ public class UpdateAdminOrdersDeliveriesTrackingNumberService implements
                     AnnounceDeliveryMessageEvent.of(
                             order.getDocumentsDescription(),
                             order.getDelivery().getTrackingNumber(),
-                            order.getOrderNumber(),
+                            order.getDelivery().getId(),
                             order.getDelivery().getPhoneNumber()
                     )
             );

--- a/src/main/java/com/tookscan/tookscan/payment/application/service/ConfirmPaymentService.java
+++ b/src/main/java/com/tookscan/tookscan/payment/application/service/ConfirmPaymentService.java
@@ -101,7 +101,7 @@ public class ConfirmPaymentService implements ConfirmPaymentUseCase {
             applicationEventPublisher.publishEvent(
                     RequestScanMessageEvent.of(
                             order.getDocumentsDescription(),
-                            order.getOrderNumber(),
+                            order.getId(),
                             order.getDelivery().getEmail(),
                             order.getDelivery().getPhoneNumber()
                     )

--- a/src/main/java/com/tookscan/tookscan/payment/application/service/CreatePaymentService.java
+++ b/src/main/java/com/tookscan/tookscan/payment/application/service/CreatePaymentService.java
@@ -49,7 +49,7 @@ public class CreatePaymentService implements CreatePaymentUseCase {
         applicationEventPublisher.publishEvent(
                 RequestScanMessageEvent.of(
                         order.getDocumentsDescription(),
-                        order.getOrderNumber(),
+                        order.getId(),
                         order.getDelivery().getEmail(),
                         order.getDelivery().getPhoneNumber()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -200,7 +200,8 @@ solapi:
   payment-url: ${SOLAPI_PAYMENT_URL}
   order-detail-url: ${SOLAPI_ORDER_DETAIL_URL}
   order-waybill-url: ${SOLAPI_ORDER_WAYBILL_URL}
-  user-post-way-1-url: ${SOLAPI_USER_POST_WAY_1_URL}
+  user-post-way-pc-url: ${SOLAPI_USER_POST_WAY_PC_URL}
+  user-post-way-mobile-url: ${SOLAPI_USER_POST_WAY_MOBILE_URL}
   user-post-way-2-url: ${SOLAPI_USER_POST_WAY_2_URL}
   post-price-url: ${SOLAPI_POST_PRICE_URL}
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #607 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 방문택배 URL을 PC 전용과 모바일 전용 분기 처리
이제 알림톡의 방문택배 버튼 클릭 시, PC의 경우 www.cupost.co.kr/postbox/home/general/selectReservation.cupost로, 모바일의 경우, www.cupost.co.kr/mobile/home/general/reservationServices.cupost로 각각에 맞는 url로 이동합니다.

- 잘못된 인자로 인한 버그 수정
직전 PR에서 변경한 알림톡 매개변수가 적용되지 않은 부분들이 있어 발생하는 버그를 수정했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 게시글 URL 설정이 PC용과 모바일용으로 분리되어 각각 별도의 URL을 지원합니다.

* **버그 수정**
  * 일부 알림 및 메시지 이벤트에서 주문번호 대신 내부 ID가 사용되어 정보 전달의 일관성이 향상되었습니다.

* **설정**
  * 환경설정에서 기존 단일 URL 항목이 PC와 모바일 구분 항목으로 대체되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->