### PR TITLE
🔨 Fix - 관리자 통계 조회 기본정렬 최신순으로 변경

### DIFF
--- a/http/order/OrderControllerHttpRequest.http
+++ b/http/order/OrderControllerHttpRequest.http
@@ -35,7 +35,6 @@ Content-Type: application/json
 ### 주문 조회
 //@no-log
 GET {{host_url}}/v1/users/orders/overviews?page=1&size=10&sort=createdAt
-Authorization: Bearer {{access_token}}
 
 ### 결제 요청
 //@no-log
@@ -44,17 +43,14 @@ PATCH {{host_url}}/v1/admins/orders/734276020051665347/payment-requests
 ### PDF 전송
 //@no-log
 POST {{host_url}}/v1/admins/orders/19/send-pdfs
-Authorization: Bearer {{access_token}}
 
 ### 관리자 주문 조회
 //@no-log
-GET {{host_url}}/v1/admins/orders/overviews?page=1&size=10&start-date=2025-02-12&end-date=2025-03-12&sort=order-date&direction=DESC
-Authorization: Bearer {{access_token}}
+GET {{host_url}}/v1/admins/orders/overviews?page=1&size=10&start-date=2025-06-01&end-date=2025-08-01&sort=order-date
 
 ### 관리자 결제 조회
 //@no-log
 GET {{host_url}}/v1/admins/orders/688623424943448498/payments/overviews
-Authorization: Bearer {{access_token}}
 
 ### 관리자 주문 상세 조회
 //@no-log
@@ -90,3 +86,7 @@ Content-Type: application/json
 {
   "tracking_number": "1234567890"
 }
+
+### 관리자 통계 조회
+//@no-log
+GET {{host_url}}/v1/admins/statistics/summaries?start-year-month=2025-06&end-year-month=2025-07

--- a/src/main/java/com/tookscan/tookscan/order/application/service/ReadStatisticsSummariesService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ReadStatisticsSummariesService.java
@@ -75,8 +75,11 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
                     , appliedCount, arrivedCount, completedCount, discardedCount, springCount, rawCount));
 
             // 다음 달로 이동
-            current = current.plusMonths(1);
+            current = current.minusMonths(1);
         }
+
+        // 6) 결과를 내림차순 정렬 (최신 월이 먼저 오도록)
+        result.sort((a, b) -> b.getYearMonth().compareTo(a.getYearMonth()));
 
         // 모든 달에 대한 통계를 구한 뒤 반환
         return ReadStatisticsSummariesResponseDto.from(result);

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
@@ -123,8 +123,8 @@ public class OrderAdminQueryV1Controller {
     })
     @GetMapping("/statistics/summaries")
     public ResponseDto<ReadStatisticsSummariesResponseDto> readStatisticsSummaries(
-            @RequestParam(value = "start-year-month", required = false) String startYearMonth,
-            @RequestParam(value = "end-year-month", required = false) String endYearMonth,
+            @RequestParam(value = "start-year-month") String startYearMonth,
+            @RequestParam(value = "end-year-month") String endYearMonth,
             @RequestParam(value = "is-applied", required = false) Boolean isApplied,
             @RequestParam(value = "is_arrived", required = false) Boolean isArrived,
             @RequestParam(value = "is_completed", required = false) Boolean isCompleted

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
@@ -209,6 +209,10 @@ public class OrderRepositoryImpl implements OrderRepository {
             }
         }
 
+        if (direction == null) {
+            direction = Direction.DESC; // 기본 정렬 방향
+        }
+
         // 데이터 조회
         List<Long> orderIds = jpaQueryFactory.select(order.id)
                 .from(order)


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #610 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 관리자 주문조회, 통계조회 기본 정렬값을 내림차순으로 변경

기존에는 direction을 명시하지 않을 경우, 기본 정렬이 오름차순이었습니다. 기획에 따라 주문조회와 통계조회의 기본 정렬을 내림차순으로 변경했습니다. (회원조회는 이미 내림차순으로 되어있기에 별도의 수정 없었습니다.)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
없다면 N/A를 작성해주세요.
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 통계 요약 조회를 위한 새로운 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 주문 목록 조회 시 정렬 방향이 지정되지 않은 경우, 기본값(DESC)으로 자동 적용됩니다.

* **기능 개선**
  * 관리자 통계 요약 조회 시 시작 연월과 종료 연월 파라미터가 필수로 변경되었습니다.
  * 통계 요약 결과가 최신 월이 먼저 오도록 정렬 방식이 개선되었습니다.

* **기타**
  * HTTP 요청 정의에서 Authorization 헤더가 제거되었습니다.
  * 일부 요청의 날짜 파라미터가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->