### PR TITLE
🔨 Fix - 관리자 운송장 번호 일괄등록 버그 및 통계 조회 성능 최적화

### DIFF
--- a/src/main/java/com/tookscan/tookscan/account/repository/UserRepository.java
+++ b/src/main/java/com/tookscan/tookscan/account/repository/UserRepository.java
@@ -25,4 +25,6 @@ public interface UserRepository {
     Page<UUID> findUserIdsByFilters(String searchType, String search, Long groupId, ESecurityProvider provider, LocalDate startDate, LocalDate endDate, Pageable pageable, String status, String sort, Direction direction);
 
     Integer countByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+    java.util.Map<String, Integer> findMonthlySignUpCounts(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/tookscan/tookscan/account/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/account/repository/impl/UserRepositoryImpl.java
@@ -67,6 +67,28 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Map<String, Integer> findMonthlySignUpCounts(LocalDateTime startDate, LocalDateTime endDate) {
+        QUser user = QUser.user;
+        
+        return jpaQueryFactory
+                .select(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", user.createdAt),
+                        user.count().intValue()
+                )
+                .from(user)
+                .where(user.createdAt.between(startDate, endDate))
+                .groupBy(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", user.createdAt)
+                )
+                .fetch()
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        tuple -> tuple.get(0, String.class),
+                        tuple -> tuple.get(1, Integer.class)
+                ));
+    }
+
+    @Override
     public Page<UUID> findUserIdsByFilters(String searchType, String search, Long groupId, ESecurityProvider provider, LocalDate startDate, LocalDate endDate, Pageable pageable, String status, String sort, Direction direction) {
         QUser user = QUser.user;
         QUserGroup userGroup = QUserGroup.userGroup;

--- a/src/main/java/com/tookscan/tookscan/order/application/service/ReadStatisticsSummariesService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ReadStatisticsSummariesService.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,8 +33,18 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
             Boolean isArrived,
             Boolean isCompleted
     ) {
-        LocalDate start = LocalDate.parse(startYearMonth + "-01");
-        LocalDate end = LocalDate.parse(endYearMonth + "-01");
+        // null인 경우 최근 6개월 기본값 설정
+        LocalDate now = LocalDate.now();
+        LocalDate start;
+        LocalDate end;
+        
+        if (startYearMonth == null || endYearMonth == null) {
+            end = now.withDayOfMonth(1);
+            start = end.minusMonths(5); // 6개월 (현재 월 포함)
+        } else {
+            start = LocalDate.parse(startYearMonth + "-01");
+            end = LocalDate.parse(endYearMonth + "-01");
+        }
 
         // 1. 트랜잭션 내에서 모든 DB 조회 결과만 수집
         List<MonthlyStatisticsDto> statistics = loadStatistics(start, end);
@@ -47,31 +58,42 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
 
     @Transactional(readOnly = true)
     protected List<MonthlyStatisticsDto> loadStatistics(LocalDate start, LocalDate end) {
+        LocalDateTime periodStart = start.atStartOfDay();
+        LocalDateTime periodEnd = end.plusMonths(1).atStartOfDay();
+        
+        // 배치 쿼리로 전체 기간의 데이터를 한 번에 조회
+        Map<String, Integer> signUpCounts = userRepository.findMonthlySignUpCounts(periodStart, periodEnd);
+        Map<String, Integer> orderCounts = orderRepository.findMonthlyOrderCounts(periodStart, periodEnd);
+        Map<String, Integer> paymentAmounts = paymentRepository.findMonthlyPaymentAmounts(periodStart, periodEnd);
+        Map<String, Map<EOrderStatus, Integer>> orderStatusCounts = orderRepository.findMonthlyOrderStatusCounts(periodStart, periodEnd);
+        Map<String, Map<ERecoveryOption, Integer>> recoveryOptionCounts = orderRepository.findMonthlyRecoveryOptionCounts(periodStart, periodEnd);
+        
         List<MonthlyStatisticsDto> result = new ArrayList<>();
         LocalDate current = start;
-
+        
         while (!current.isAfter(end)) {
-            LocalDateTime monthStart = current.atStartOfDay();
-            LocalDateTime monthEnd = current.plusMonths(1).atStartOfDay();
-
-            Integer signUpCount = userRepository.countByCreatedAtBetween(monthStart, monthEnd);
-            Integer orderCount = orderRepository.countByCreatedAtBetween(monthStart, monthEnd);
-            Integer totalAmount = paymentRepository.sumTotalAmountByCreatedAtBetween(monthStart, monthEnd);
-            if (totalAmount == null) totalAmount = 0;
-
             String yearMonth = String.format("%04d-%02d", current.getYear(), current.getMonthValue());
-
+            
+            Integer signUpCount = signUpCounts.getOrDefault(yearMonth, 0);
+            Integer orderCount = orderCounts.getOrDefault(yearMonth, 0);
+            Integer totalAmount = paymentAmounts.getOrDefault(yearMonth, 0);
+            
+            // 주문 상태별 통계
+            Map<EOrderStatus, Integer> statusMap = orderStatusCounts.getOrDefault(yearMonth, Map.of());
+            Integer appliedCount = statusMap.getOrDefault(EOrderStatus.APPLY_COMPLETED, 0);
+            Integer arrivedCount = statusMap.getOrDefault(EOrderStatus.COMPANY_ARRIVED, 0);
+            Integer completedCount = statusMap.getOrDefault(EOrderStatus.ALL_COMPLETED, 0);
+            
+            // 복구 옵션별 통계
+            Map<ERecoveryOption, Integer> recoveryMap = recoveryOptionCounts.getOrDefault(yearMonth, Map.of());
+            Integer discardedCount = recoveryMap.getOrDefault(ERecoveryOption.DISCARD, 0);
+            Integer springCount = recoveryMap.getOrDefault(ERecoveryOption.SPRING, 0);
+            Integer rawCount = recoveryMap.getOrDefault(ERecoveryOption.RAW, 0);
+            
+            // 현재는 하드코딩된 값 (추후 구글 애널리틱스 연동 시 수정)
             Integer pageViewCount = 0;
             Integer visitantCount = 0;
-
-            Integer appliedCount = orderRepository.countByCreatedAtBetweenAndOrderStatus(monthStart, monthEnd, EOrderStatus.APPLY_COMPLETED);
-            Integer arrivedCount = orderRepository.countByCreatedAtBetweenAndOrderStatus(monthStart, monthEnd, EOrderStatus.COMPANY_ARRIVED);
-            Integer completedCount = orderRepository.countByCreatedAtBetweenAndOrderStatus(monthStart, monthEnd, EOrderStatus.ALL_COMPLETED);
-
-            Integer discardedCount = orderRepository.countByCreatedAtBetweenAndRecoveryOption(monthStart, monthEnd, ERecoveryOption.DISCARD);
-            Integer springCount = orderRepository.countByCreatedAtBetweenAndRecoveryOption(monthStart, monthEnd, ERecoveryOption.SPRING);
-            Integer rawCount = orderRepository.countByCreatedAtBetweenAndRecoveryOption(monthStart, monthEnd, ERecoveryOption.RAW);
-
+            
             result.add(MonthlyStatisticsDto.of(
                     yearMonth,
                     pageViewCount,
@@ -85,10 +107,10 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
                     springCount,
                     rawCount
             ));
-
-            current = current.minusMonths(1);
+            
+            current = current.plusMonths(1);
         }
-
+        
         return result;
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrdersDeliveriesTrackingNumberService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UpdateAdminOrdersDeliveriesTrackingNumberService.java
@@ -43,8 +43,8 @@ public class UpdateAdminOrdersDeliveriesTrackingNumberService implements
 
         // 1) 엑셀 → (주문번호, 트래킹번호) 리스트
         List<MyOrderExcelRow> rowDataList = excelUtils.parseExcel(file, 1, (row, rowNum) -> {
-                    String orderNumber = excelUtils.getStringCellValue(row.getCell(0)); // A열
-                    String trackingNumber = excelUtils.getStringCellValue(row.getCell(5)); // F열
+                    String orderNumber = excelUtils.getStringCellValue(row.getCell(3)); // D열
+                    String trackingNumber = excelUtils.getStringCellValue(row.getCell(0)); // A열
                     if (orderNumber.isEmpty() && trackingNumber.isEmpty()) {
                         return null;
                     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
@@ -123,11 +123,11 @@ public class OrderAdminQueryV1Controller {
     })
     @GetMapping("/statistics/summaries")
     public ResponseDto<ReadStatisticsSummariesResponseDto> readStatisticsSummaries(
-            @RequestParam(value = "start-year-month") String startYearMonth,
-            @RequestParam(value = "end-year-month") String endYearMonth,
+            @RequestParam(value = "start-year-month", required = false) String startYearMonth,
+            @RequestParam(value = "end-year-month", required = false) String endYearMonth,
             @RequestParam(value = "is-applied", required = false) Boolean isApplied,
-            @RequestParam(value = "is_arrived", required = false) Boolean isArrived,
-            @RequestParam(value = "is_completed", required = false) Boolean isCompleted
+            @RequestParam(value = "is-arrived", required = false) Boolean isArrived,
+            @RequestParam(value = "is-completed", required = false) Boolean isCompleted
     ) {
         return ResponseDto.ok(readStatisticsSummariesUseCase.execute(startYearMonth, endYearMonth,
                 isApplied, isArrived, isCompleted));

--- a/src/main/java/com/tookscan/tookscan/order/repository/OrderRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/OrderRepository.java
@@ -71,6 +71,12 @@ public interface OrderRepository {
 
     Integer countByCreatedAtBetweenAndRecoveryOption(LocalDateTime startDate, LocalDateTime endDate, ERecoveryOption recoveryOption);
 
+    Map<String, Integer> findMonthlyOrderCounts(LocalDateTime startDate, LocalDateTime endDate);
+
+    Map<String, Map<EOrderStatus, Integer>> findMonthlyOrderStatusCounts(LocalDateTime startDate, LocalDateTime endDate);
+
+    Map<String, Map<ERecoveryOption, Integer>> findMonthlyRecoveryOptionCounts(LocalDateTime startDate, LocalDateTime endDate);
+
     Order findByIdWithDocumentsOrElseThrow(Long id);
 
     Order findByIdWithDocumentsAndDeliveryOrElseThrow(Long id);

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
@@ -2,12 +2,14 @@ package com.tookscan.tookscan.order.repository.impl;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tookscan.tookscan.account.domain.User;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Order;
 import com.tookscan.tookscan.order.domain.QOrder;
+import com.tookscan.tookscan.order.domain.QDocument;
 import com.tookscan.tookscan.order.domain.type.EOrderStatus;
 import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
 import com.tookscan.tookscan.order.repository.OrderRepository;
@@ -382,6 +384,84 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public Integer countByCreatedAtBetweenAndRecoveryOption(LocalDateTime startDate, LocalDateTime endDate, ERecoveryOption recoveryOption) {
         return orderJpaRepository.countByCreatedAtBetweenAndRecoveryOption(startDate, endDate, recoveryOption);
+    }
+
+    @Override
+    public Map<String, Integer> findMonthlyOrderCounts(LocalDateTime startDate, LocalDateTime endDate) {
+        QOrder order = QOrder.order;
+        
+        return jpaQueryFactory
+                .select(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", order.createdAt),
+                        order.count().intValue()
+                )
+                .from(order)
+                .where(order.createdAt.between(startDate, endDate))
+                .groupBy(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", order.createdAt)
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, String.class),
+                        tuple -> tuple.get(1, Integer.class)
+                ));
+    }
+
+    @Override
+    public Map<String, Map<EOrderStatus, Integer>> findMonthlyOrderStatusCounts(LocalDateTime startDate, LocalDateTime endDate) {
+        QOrder order = QOrder.order;
+        
+        return jpaQueryFactory
+                .select(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", order.createdAt),
+                        order.orderStatus,
+                        order.count().intValue()
+                )
+                .from(order)
+                .where(order.createdAt.between(startDate, endDate))
+                .groupBy(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", order.createdAt),
+                        order.orderStatus
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(0, String.class),
+                        Collectors.toMap(
+                                tuple -> tuple.get(1, EOrderStatus.class),
+                                tuple -> tuple.get(2, Integer.class)
+                        )
+                ));
+    }
+
+    @Override
+    public Map<String, Map<ERecoveryOption, Integer>> findMonthlyRecoveryOptionCounts(LocalDateTime startDate, LocalDateTime endDate) {
+        QOrder order = QOrder.order;
+        QDocument document = QDocument.document;
+        
+        return jpaQueryFactory
+                .select(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", order.createdAt),
+                        document.recoveryOption,
+                        order.count().intValue()
+                )
+                .from(order)
+                .join(order.documents, document)
+                .where(order.createdAt.between(startDate, endDate))
+                .groupBy(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", order.createdAt),
+                        document.recoveryOption
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(0, String.class),
+                        Collectors.toMap(
+                                tuple -> tuple.get(1, ERecoveryOption.class),
+                                tuple -> tuple.get(2, Integer.class)
+                        )
+                ));
     }
 
     @Override

--- a/src/main/java/com/tookscan/tookscan/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/tookscan/tookscan/payment/repository/PaymentRepository.java
@@ -6,6 +6,8 @@ import java.time.LocalDateTime;
 
 public interface PaymentRepository {
     Integer sumTotalAmountByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+    
+    java.util.Map<String, Integer> findMonthlyPaymentAmounts(LocalDateTime startDate, LocalDateTime endDate);
     Payment saveAndReturn(Payment payment);
     Payment findByIdOrElseThrow(Long id);
     void save(Payment payment);

--- a/src/main/java/com/tookscan/tookscan/payment/repository/impl/PaymentRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/payment/repository/impl/PaymentRepositoryImpl.java
@@ -1,10 +1,15 @@
 package com.tookscan.tookscan.payment.repository.impl;
 
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.payment.domain.Payment;
+import com.tookscan.tookscan.payment.domain.QPayment;
 import com.tookscan.tookscan.payment.repository.PaymentRepository;
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.tookscan.tookscan.payment.repository.mysql.PaymentJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +19,33 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class PaymentRepositoryImpl implements PaymentRepository {
     private final PaymentJpaRepository paymentJpaRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public Integer sumTotalAmountByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate) {
         return paymentJpaRepository.sumTotalAmountByCreatedAtBetween(startDate, endDate);
+    }
+
+    @Override
+    public Map<String, Integer> findMonthlyPaymentAmounts(LocalDateTime startDate, LocalDateTime endDate) {
+        QPayment payment = QPayment.payment;
+        
+        return jpaQueryFactory
+                .select(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", payment.createdAt),
+                        payment.totalAmount.sum().intValue()
+                )
+                .from(payment)
+                .where(payment.createdAt.between(startDate, endDate))
+                .groupBy(
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m')", payment.createdAt)
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, String.class),
+                        tuple -> tuple.get(1, Integer.class)
+                ));
     }
     @Override
     public Payment saveAndReturn(Payment payment) {


### PR DESCRIPTION
## Related issue 🛠
closed #622

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix
- [ ] ✨ Feature: New feature
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
작업 내용을 작성해주세요.
- **관리자 운송장 번호 일괄등록 버그 수정**: 엑셀 파일에서 읽어오는 컬럼 순서 수정 (D열: 주문번호, A열: 운송장번호)
- **관리자 통계 조회 성능 최적화**: 개별 쿼리를 배치 쿼리로 변경하여 성능 개선
  - 월별 가입자 수, 주문 수, 결제 금액, 주문 상태별, 복구 옵션별 통계를 한 번의 쿼리로 처리
  - 통계 조회 API 파라미터를 optional로 변경하여 기본값(최근 6개월) 제공
  - 요청 파라미터명 오타 수정 (`is_arrived` → `is-arrived`, `is_completed` → `is-completed`)

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 운송장 번호 일괄등록 시 엑셀 파일의 컬럼 순서가 변경되었습니다 (D열: 주문번호, A열: 운송장번호)
- 통계 조회 성능 개선을 위해 각 Repository에 배치 쿼리 메서드가 추가되었습니다
- 통계 조회 API에서 날짜 파라미터가 선택사항으로 변경되어 기본값으로 최근 6개월 데이터를 제공합니다
- 기존 개별 쿼리 방식에서 배치 쿼리 방식으로 변경하여 DB 호출 횟수를 대폭 줄였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 월별 회원 가입, 주문, 결제, 주문 상태, 복구 옵션 통계 데이터를 한 번에 조회할 수 있는 기능이 추가되었습니다.
  * 통계 요약 조회 시 날짜 범위가 입력되지 않으면 최근 6개월로 자동 설정됩니다.

* **버그 수정**
  * 관리자 주문 배송번호 엑셀 업로드 시 주문번호와 운송장번호 컬럼 위치가 변경되었습니다.

* **개선 사항**
  * 통계 데이터 조회 시 월별 데이터를 일괄로 불러오는 방식으로 성능이 향상되었습니다.
  * 관리자 통계 조회 API의 파라미터명이 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->