### PR TITLE
🔨 Fix - SQLDelete 잘못된 테이블 명으로 인해 발생하는 쿠폰 삭제 버그 수정

### DIFF
--- a/http/order/OrderControllerHttpRequest.http
+++ b/http/order/OrderControllerHttpRequest.http
@@ -130,3 +130,7 @@ GET {{host_url}}/v1/admins/coupon-templates/738695615050511029/issued-coupons/ov
 ### 관리자 사용 쿠폰 요약 조회
 //@no-log
 GET {{host_url}}/v1/admins/coupon-templates/738696461221983066/used-coupons/overviews
+
+### 관리자 쿠폰 템플릿 삭제
+//@no-log
+DELETE {{host_url}}/v1/admins/coupon-templates/738695615050511029

--- a/src/main/java/com/tookscan/tookscan/order/domain/CouponTemplate.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/CouponTemplate.java
@@ -24,7 +24,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "coupon_templates")
-@SQLDelete(sql = "UPDATE coupons SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE coupon_templates SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class CouponTemplate extends BaseEntity {
 

--- a/src/main/java/com/tookscan/tookscan/order/domain/IssuedCoupon.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/IssuedCoupon.java
@@ -24,7 +24,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "issued_coupons")
-@SQLDelete(sql = "UPDATE coupons SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE issued_coupons SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class IssuedCoupon extends BaseEntity {
 

--- a/src/main/java/com/tookscan/tookscan/order/domain/UsedCoupon.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/UsedCoupon.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "used_coupons")
-@SQLDelete(sql = "UPDATE coupons SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE used_coupons SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class UsedCoupon extends BaseEntity {
     /* -------------------------------------------- */


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #647 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- SQLDelete 잘못된 테이블 명으로 인해 발생하는 쿠폰 삭제 버그 수정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자용 쿠폰 템플릿 삭제 API가 추가되었습니다.

* **Bug Fixes**
  * 쿠폰 관련 데이터 삭제 시 올바른 테이블의 삭제 처리(`deleted_at` 업데이트)가 적용되어 데이터 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->