### PR TITLE
🔨 Fix - 이메일 pdf 파일 이름 매칭 안되는 버그 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
@@ -109,7 +109,7 @@ public class S3Util {
         String s3Key = buildPdfS3Key(document, uniqueFileName);
 
         try {
-            String contentDisposition = "attachment; filename*=UTF-8''" + java.net.URLEncoder.encode(originalFileName,
+            String contentDisposition = "inline; filename*=UTF-8''" + java.net.URLEncoder.encode(originalFileName,
                     java.nio.charset.StandardCharsets.UTF_8);
 
             // 1. S3에 파일 업로드

--- a/src/main/java/com/tookscan/tookscan/order/domain/Order.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Order.java
@@ -324,18 +324,16 @@ public class Order extends BaseEntity {
                     String content = "<li style=\"margin-bottom: 10px;\">";
                     content += "- \uD83D\uDCC1 " + doc.getName() + "<ul style=\"list-style: none; margin: 6px 0 0 18px; padding: 0;\">";
                     content += "<ul style=\"list-style: none; margin: 6px 0 0 18px; padding: 0;\">";
-                    int pdfCount = 1;
                     for (Pdf pdf : pdfs) {
                         if (pdf.getPdfUrlForUser() != null) {
                             if (pdfs.size() > 1) {
                                 content += "<li>└ \uD83D\uDCC4<a href=\"" + pdf.getPdfUrlForUser()
-                                        + "\" style=\"color:#1a73e8; text-decoration:none;\">" + pdf.getDocument()
-                                        .getName() + " (" + pdfCount + ")" + "</a></li>";
-                                pdfCount++;
+                                        + "\" style=\"color:#1a73e8; text-decoration:none;\">" + pdf.getName()
+                                        + "</a></li>";
                             } else {
                                 content += "<li>└ \uD83D\uDCC4<a href=\"" + pdf.getPdfUrlForUser()
-                                        + "\" style=\"color:#1a73e8; text-decoration:none;\">" + pdf.getDocument()
-                                        .getName() + "</a></li>";
+                                        + "\" style=\"color:#1a73e8; text-decoration:none;\">" + pdf.getName()
+                                        + "</a></li>";
                             }
                         } else {
                             content += "<li style=\"margin-bottom: 6px;\">- 📁 <span style=\"color:#888888;\">PDF 파일이 준비되지 않았습니다.</span></li>";


### PR DESCRIPTION
## Related issue 🛠
closed #671

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix
- [ ] ✨ Feature: New feature
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
이메일 PDF 파일 이름 매칭 문제 수정 및 보안 개선 작업을 진행했습니다.

### 주요 변경사항:
- **PDF 파일 이름 매칭 수정**: Order.java의 이메일 템플릿에서 PDF 파일 이름이 Document 이름으로 표시되던 문제를 PDF의 실제 이름으로 수정
- **JWT 토큰 자동 재발급 로직 추가**: 액세스 토큰 만료 시 리프레시 토큰으로 자동 재발급하는 기능 구현
- **예외 처리 최적화**: 클라이언트 측 오류에 대한 불필요한 Slack 알림 제거
- **사용자 관리 개선**: 관리자 사용자 상세 정보에 탈퇴 여부 필드 추가

### 세부 변경사항:
1. **Order.java**: 이메일 PDF 링크에서 `pdf.getDocument().getName()` → `pdf.getName()`으로 수정
2. **JsonWebTokenAuthenticationFilter.java**: 액세스 토큰 만료 시 자동 재발급 로직 및 쿠키 정리 기능 추가
3. **HttpGlobalExceptionHandler.java**: 클라이언트 측 오류(4xx)에 대한 Slack 알림 제거, 서버 측 오류(5xx)만 알림 발송
4. **ReadAdminUserDetailResponseDto.java**: 사용자 탈퇴 여부를 명시적으로 표시하는 `isDeleted` 필드 추가
5. **SecurityConfig.java**: JWT 재발급 UseCase 의존성 추가

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
### 주요 검토 포인트:
1. **PDF 파일 이름 표시**: 이메일에서 PDF 파일 이름이 올바르게 표시되는지 확인
2. **JWT 자동 재발급**: 액세스 토큰 만료 시 자동으로 재발급되고 기존 요청이 정상 처리되는지 확인
3. **예외 처리**: 클라이언트 오류에 대한 Slack 알림이 발송되지 않는지 확인
4. **보안**: 토큰 관련 쿠키가 적절히 정리되는지 확인

### 테스트 권장사항:
- 이메일 발송 시 PDF 파일 이름 확인
- 액세스 토큰 만료 상황에서의 자동 재발급 동작 확인
- 유효하지 않은 토큰 사용 시 쿠키 정리 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 여러 PDF가 있을 때 PDF 링크에 번호가 붙지 않고, 각 PDF의 이름만 표시되도록 개선되었습니다.
  * PDF 파일을 열 때 브라우저에서 바로 보기(inline)로 처리되도록 변경되어 다운로드 없이 바로 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->