### PR TITLE
🔨 Fix - 어드민 주문 목록 조회에 customer-key 필터 추가

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/application/service/ReadAdminOrderOverviewsService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ReadAdminOrderOverviewsService.java
@@ -6,6 +6,8 @@ import com.tookscan.tookscan.order.domain.type.EOrderStatus;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderOverviewsResponseDto;
 import com.tookscan.tookscan.order.repository.OrderRepository;
 import java.util.List;
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,12 +28,12 @@ public class ReadAdminOrderOverviewsService implements ReadAdminOrderOverviewsUs
                                                       String search, String searchType, String sort,
                                                       Direction direction, EOrderStatus orderStatus,
                                                       Boolean isOneDayScan, Boolean hasRecoveryOption,
-                                                      Boolean isAsInProgress, Boolean isInProgress) {
+                                                      Boolean isAsInProgress, Boolean isInProgress, UUID customerKey) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
         Page<Long> orderIdPages = orderRepository.findOrderOverviews(startDate, endDate, search,
                 searchType, sort, direction, pageable, orderStatus, isOneDayScan, hasRecoveryOption, isAsInProgress,
-                isInProgress);
+                isInProgress, customerKey);
 
         List<Order> orders = orderRepository.findAllWithDocumentsByIdIn(orderIdPages.getContent());
 

--- a/src/main/java/com/tookscan/tookscan/order/application/usecase/ReadAdminOrderOverviewsUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/usecase/ReadAdminOrderOverviewsUseCase.java
@@ -5,11 +5,13 @@ import com.tookscan.tookscan.order.domain.type.EOrderStatus;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderOverviewsResponseDto;
 import org.springframework.data.domain.Sort.Direction;
 
+import java.util.UUID;
+
 @UseCase
 public interface ReadAdminOrderOverviewsUseCase {
     ReadAdminOrderOverviewsResponseDto execute(int page, int size, String startDate, String endDate, String search,
                                                String searchType, String sort, Direction direction,
                                                EOrderStatus orderStatus, Boolean isOneDayScan,
                                                Boolean hasRecoveryOption,
-                                               Boolean isAsInProgress, Boolean isInProgress);
+                                               Boolean isAsInProgress, Boolean isInProgress, UUID customerKey);
 }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
@@ -36,6 +36,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @Tag(name = "Order", description = "Order 관련 API 입니다.")
 @RestController
 @RequiredArgsConstructor
@@ -118,11 +120,12 @@ public class OrderAdminQueryV1Controller {
             @RequestParam(value = "is-one-day-scan", required = false) Boolean isOneDayScan,
             @RequestParam(value = "has-recovery-option", required = false) Boolean hasRecoveryOption,
             @RequestParam(value = "is-as-in-progress", required = false) Boolean isAsInProgress,
-            @RequestParam(value = "is-in-progress", required = false) Boolean isInProgress
+            @RequestParam(value = "is-in-progress", required = false) Boolean isInProgress,
+            @RequestParam(value = "customer-key", required = false) UUID customerKey
     ) {
         return ResponseDto.ok(
                 readAdminOrderOverviewsUseCase.execute(page, size, startDate, endDate, search,
-                        searchType, sort, direction, orderStatus, isOneDayScan, hasRecoveryOption, isAsInProgress, isInProgress));
+                        searchType, sort, direction, orderStatus, isOneDayScan, hasRecoveryOption, isAsInProgress, isInProgress, customerKey));
     }
 
 

--- a/src/main/java/com/tookscan/tookscan/order/repository/OrderRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/OrderRepository.java
@@ -40,7 +40,7 @@ public interface OrderRepository {
     Page<Long> findOrderOverviews(String startDate, String endDate,
                                   String search, String searchType, String sort, Direction direction,
                                   Pageable pageable, EOrderStatus orderStatus, Boolean isOneDayScan,
-                                  Boolean hasRecoveryOption, Boolean isAsInProgress, Boolean isInProgress);
+                                  Boolean hasRecoveryOption, Boolean isAsInProgress, Boolean isInProgress, UUID customerKey);
 
     Page<Long> findDeliveriesSummaries(String startDate, String endDate, String search, String searchType,
                                        EOrderStatus orderStatus,

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
@@ -170,7 +170,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     public Page<Long> findOrderOverviews(String startDate, String endDate,
                                          String search, String searchType, String sort, Direction direction,
                                          Pageable pageable, EOrderStatus orderStatus, Boolean isOneDayScan,
-                                         Boolean hasRecoveryOption, Boolean isAsInProgress, Boolean isInProgress) {
+                                         Boolean hasRecoveryOption, Boolean isAsInProgress, Boolean isInProgress, UUID customerKey) {
         QOrder order = QOrder.order;
 
         // 검색 조건 동적 생성
@@ -223,6 +223,11 @@ public class OrderRepositoryImpl implements OrderRepository {
             }
         }
 
+        if (customerKey != null) {
+            // customerKey가 있는 경우, 해당 키로 필터링
+            predicate = predicate.and(order.user.id.eq(customerKey));
+        }
+
         if (direction == null) {
             direction = Direction.DESC; // 기본 정렬 방향
         }
@@ -230,6 +235,7 @@ public class OrderRepositoryImpl implements OrderRepository {
         // 데이터 조회
         List<Long> orderIds = jpaQueryFactory.select(order.id)
                 .from(order)
+                .join(order.user).fetchJoin()
                 .where(predicate)
                 .orderBy(resolveSort(order, sort, direction))
                 .offset(pageable.getOffset())


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #684 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 어드민 주문 목록 조회에 customer-key 필터 추가

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 주문 목록 조회 시 고객 키(UUID)로 주문을 필터링할 수 있는 기능이 추가되었습니다.  
  * 주문 목록 조회 API에서 선택적으로 customer-key 파라미터를 입력하여 특정 고객의 주문만 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->