### PR TITLE
🔨 Fix - 관리자 페이지 통계 조회 응답값 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/application/service/ReadStatisticsSummariesService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ReadStatisticsSummariesService.java
@@ -1,11 +1,11 @@
 package com.tookscan.tookscan.order.application.service;
 
 import com.tookscan.tookscan.account.repository.UserRepository;
+import com.tookscan.tookscan.order.application.usecase.ReadStatisticsSummariesUseCase;
 import com.tookscan.tookscan.order.domain.type.EOrderStatus;
 import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadStatisticsSummariesResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadStatisticsSummariesResponseDto.MonthlyStatisticsDto;
-import com.tookscan.tookscan.order.application.usecase.ReadStatisticsSummariesUseCase;
 import com.tookscan.tookscan.order.repository.OrderRepository;
 import com.tookscan.tookscan.payment.repository.PaymentRepository;
 import java.time.LocalDate;
@@ -70,7 +70,7 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
         // 필터링된 월별 복구 옵션별 통계
         Map<String, Map<ERecoveryOption, Integer>> recoveryOptionCounts = orderRepository.findMonthlyRecoveryOptionCounts(periodStart, periodEnd, isApplied, isArrived, isCompleted);
         Map<String, Map<ERecoveryOption, Double>> recoveryOptionAveragePageCounts = orderRepository.findMonthlyRecoveryOptionAveragePageCounts(periodStart, periodEnd, isApplied, isArrived, isCompleted);
-        Map<String, Map<ERecoveryOption, Double>> recoveryOptionAverageBookPrices = orderRepository.findMonthlyRecoveryOptionAverageBookPrices(periodStart, periodEnd, isApplied, isArrived, isCompleted);
+        Map<String, Map<ERecoveryOption, Double>> recoveryOptionAverageDocumentPrices = orderRepository.findMonthlyRecoveryOptionAverageDocumentPrices(periodStart, periodEnd, isApplied, isArrived, isCompleted);
         
         List<MonthlyStatisticsDto> result = new ArrayList<>();
         LocalDate current = start;
@@ -100,11 +100,12 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
             Double rawAvgPageCount = avgPageCountMap.getOrDefault(ERecoveryOption.RAW, 0.0);
             Double discardAvgPageCount = avgPageCountMap.getOrDefault(ERecoveryOption.DISCARD, 0.0);
             
-            // 복구 옵션별 평균 책 금액
-            Map<ERecoveryOption, Double> avgBookPriceMap = recoveryOptionAverageBookPrices.getOrDefault(yearMonth, Map.of());
-            Double springAvgBookPrice = avgBookPriceMap.getOrDefault(ERecoveryOption.SPRING, 0.0);
-            Double rawAvgBookPrice = avgBookPriceMap.getOrDefault(ERecoveryOption.RAW, 0.0);
-            Double discardAvgBookPrice = avgBookPriceMap.getOrDefault(ERecoveryOption.DISCARD, 0.0);
+            // 복구 옵션별 평균 문서 금액
+            Map<ERecoveryOption, Double> avgDocumentPriceMap = recoveryOptionAverageDocumentPrices.getOrDefault(yearMonth,
+                    Map.of());
+            Double springAvgDocumentPrice = avgDocumentPriceMap.getOrDefault(ERecoveryOption.SPRING, 0.0);
+            Double rawAvgDocumentPrice = avgDocumentPriceMap.getOrDefault(ERecoveryOption.RAW, 0.0);
+            Double discardAvgDocumentPrice = avgDocumentPriceMap.getOrDefault(ERecoveryOption.DISCARD, 0.0);
             
             // 현재는 하드코딩된 값 (추후 구글 애널리틱스 연동 시 수정)
             Integer pageViewCount = 0;
@@ -125,9 +126,9 @@ public class ReadStatisticsSummariesService implements ReadStatisticsSummariesUs
                     springAvgPageCount,
                     rawAvgPageCount,
                     discardAvgPageCount,
-                    springAvgBookPrice,
-                    rawAvgBookPrice,
-                    discardAvgBookPrice
+                    springAvgDocumentPrice,
+                    rawAvgDocumentPrice,
+                    discardAvgDocumentPrice
             ));
             
             current = current.plusMonths(1);

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadStatisticsSummariesResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadStatisticsSummariesResponseDto.java
@@ -17,12 +17,16 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
     @JsonProperty("statistics")
     private final List<MonthlyStatisticsDto> statistics;
 
+    @JsonProperty("total_statistics")
+    private final TotalStatisticsDto totalStatistics;
+
     @Builder
     public ReadStatisticsSummariesResponseDto(Integer todayVisitantCount, Integer todayPageViewCount,
-                                              List<MonthlyStatisticsDto> statistics) {
+                                              List<MonthlyStatisticsDto> statistics, TotalStatisticsDto totalStatistics) {
         this.todayVisitantCount = todayVisitantCount;
         this.todayPageViewCount = todayPageViewCount;
         this.statistics = statistics;
+        this.totalStatistics = totalStatistics != null ? totalStatistics : calculateTotalStatistics(statistics);
         this.validateSelf();
     }
 
@@ -31,6 +35,74 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
                 .todayVisitantCount(statisticsDto.stream().mapToInt(MonthlyStatisticsDto::getVisitantCount).sum())
                 .todayPageViewCount(statisticsDto.stream().mapToInt(MonthlyStatisticsDto::getPageViewCount).sum())
                 .statistics(statisticsDto)
+                .totalStatistics(calculateTotalStatistics(statisticsDto))
+                .build();
+    }
+
+    /**
+     * 모든 월별 통계의 총 평균을 계산
+     */
+    private static TotalStatisticsDto calculateTotalStatistics(List<MonthlyStatisticsDto> statistics) {
+        if (statistics == null || statistics.isEmpty()) {
+            return TotalStatisticsDto.builder()
+                    .discardedCount(0)
+                    .springCount(0)
+                    .rawCount(0)
+                    .springAveragePageCount(0.0)
+                    .rawAveragePageCount(0.0)
+                    .discardAveragePageCount(0.0)
+                    .springAverageDocumentPrice(0.0)
+                    .rawAverageDocumentPrice(0.0)
+                    .discardAverageDocumentPrice(0.0)
+                    .build();
+        }
+
+        // 총합 계산
+        Integer totalDiscardedCount = statistics.stream().mapToInt(MonthlyStatisticsDto::getDiscardedCount).sum();
+        Integer totalSpringCount = statistics.stream().mapToInt(MonthlyStatisticsDto::getSpringCount).sum();
+        Integer totalRawCount = statistics.stream().mapToInt(MonthlyStatisticsDto::getRawCount).sum();
+
+        // 평균 계산 (모든 달에 대한 평균)
+        Double avgSpringPageCount = statistics.stream()
+                .mapToDouble(MonthlyStatisticsDto::getSpringAveragePageCount)
+                .average()
+                .orElse(0.0);
+
+        Double avgRawPageCount = statistics.stream()
+                .mapToDouble(MonthlyStatisticsDto::getRawAveragePageCount)
+                .average()
+                .orElse(0.0);
+
+        Double avgDiscardPageCount = statistics.stream()
+                .mapToDouble(MonthlyStatisticsDto::getDiscardAveragePageCount)
+                .average()
+                .orElse(0.0);
+
+        Double avgSpringDocumentPrice = statistics.stream()
+                .mapToDouble(MonthlyStatisticsDto::getSpringAverageDocumentPrice)
+                .average()
+                .orElse(0.0);
+
+        Double avgRawDocumentPrice = statistics.stream()
+                .mapToDouble(MonthlyStatisticsDto::getRawAverageDocumentPrice)
+                .average()
+                .orElse(0.0);
+
+        Double avgDiscardDocumentPrice = statistics.stream()
+                .mapToDouble(MonthlyStatisticsDto::getDiscardAverageDocumentPrice)
+                .average()
+                .orElse(0.0);
+
+        return TotalStatisticsDto.builder()
+                .discardedCount(totalDiscardedCount)
+                .springCount(totalSpringCount)
+                .rawCount(totalRawCount)
+                .springAveragePageCount(avgSpringPageCount)
+                .rawAveragePageCount(avgRawPageCount)
+                .discardAveragePageCount(avgDiscardPageCount)
+                .springAverageDocumentPrice(avgSpringDocumentPrice)
+                .rawAverageDocumentPrice(avgRawDocumentPrice)
+                .discardAverageDocumentPrice(avgDiscardDocumentPrice)
                 .build();
     }
 
@@ -78,14 +150,14 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
         @JsonProperty("discard_average_page_count")
         private final Double discardAveragePageCount;
 
-        @JsonProperty("spring_average_book_price")
-        private final Double springAverageBookPrice;
+        @JsonProperty("spring_average_document_price")
+        private final Double springAverageDocumentPrice;
 
-        @JsonProperty("raw_average_book_price")
-        private final Double rawAverageBookPrice;
+        @JsonProperty("raw_average_document_price")
+        private final Double rawAverageDocumentPrice;
 
-        @JsonProperty("discard_average_book_price")
-        private final Double discardAverageBookPrice;
+        @JsonProperty("discard_average_document_price")
+        private final Double discardAverageDocumentPrice;
 
         @Builder
         public MonthlyStatisticsDto(String yearMonth, Integer pageViewCount, Integer visitantCount,
@@ -93,7 +165,8 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
                                     Integer arrivedCount, Integer completedCount, Integer discardedCount,
                                     Integer springCount, Integer rawCount,
                                     Double springAveragePageCount, Double rawAveragePageCount, Double discardAveragePageCount,
-                                    Double springAverageBookPrice, Double rawAverageBookPrice, Double discardAverageBookPrice) {
+                                    Double springAverageDocumentPrice, Double rawAverageDocumentPrice,
+                                    Double discardAverageDocumentPrice) {
             this.yearMonth = yearMonth;
             this.pageViewCount = pageViewCount;
             this.visitantCount = visitantCount;
@@ -108,9 +181,12 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
             this.springAveragePageCount = springAveragePageCount != null ? Math.round(springAveragePageCount * 10.0) / 10.0 : 0.0;
             this.rawAveragePageCount = rawAveragePageCount != null ? Math.round(rawAveragePageCount * 10.0) / 10.0 : 0.0;
             this.discardAveragePageCount = discardAveragePageCount != null ? Math.round(discardAveragePageCount * 10.0) / 10.0 : 0.0;
-            this.springAverageBookPrice = springAverageBookPrice != null ? Math.round(springAverageBookPrice * 10.0) / 10.0 : 0.0;
-            this.rawAverageBookPrice = rawAverageBookPrice != null ? Math.round(rawAverageBookPrice * 10.0) / 10.0 : 0.0;
-            this.discardAverageBookPrice = discardAverageBookPrice != null ? Math.round(discardAverageBookPrice * 10.0) / 10.0 : 0.0;
+            this.springAverageDocumentPrice =
+                    springAverageDocumentPrice != null ? Math.round(springAverageDocumentPrice * 10.0) / 10.0 : 0.0;
+            this.rawAverageDocumentPrice =
+                    rawAverageDocumentPrice != null ? Math.round(rawAverageDocumentPrice * 10.0) / 10.0 : 0.0;
+            this.discardAverageDocumentPrice =
+                    discardAverageDocumentPrice != null ? Math.round(discardAverageDocumentPrice * 10.0) / 10.0 : 0.0;
         }
 
         public static MonthlyStatisticsDto of(String yearMonth, Integer pageViewCount, Integer visitantCount,
@@ -118,7 +194,8 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
                                                 Integer arrivedCount, Integer completedCount,
                                                 Integer discardedCount, Integer springCount, Integer rawCount,
                                                 Double springAveragePageCount, Double rawAveragePageCount, Double discardAveragePageCount,
-                                                Double springAverageBookPrice, Double rawAverageBookPrice, Double discardAverageBookPrice) {
+                                              Double springAverageDocumentPrice, Double rawAverageDocumentPrice,
+                                              Double discardAverageDocumentPrice) {
             return MonthlyStatisticsDto.builder()
                     .yearMonth(yearMonth)
                     .pageViewCount(pageViewCount)
@@ -134,10 +211,64 @@ public class ReadStatisticsSummariesResponseDto extends SelfValidating<ReadStati
                     .springAveragePageCount(springAveragePageCount)
                     .rawAveragePageCount(rawAveragePageCount)
                     .discardAveragePageCount(discardAveragePageCount)
-                    .springAverageBookPrice(springAverageBookPrice)
-                    .rawAverageBookPrice(rawAverageBookPrice)
-                    .discardAverageBookPrice(discardAverageBookPrice)
+                    .springAverageDocumentPrice(springAverageDocumentPrice)
+                    .rawAverageDocumentPrice(rawAverageDocumentPrice)
+                    .discardAverageDocumentPrice(discardAverageDocumentPrice)
                     .build();
         }
     }
+
+    @Getter
+    public static class TotalStatisticsDto {
+        @JsonProperty("discarded_count")
+        private final Integer discardedCount;
+
+        @JsonProperty("spring_count")
+        private final Integer springCount;
+
+        @JsonProperty("raw_count")
+        private final Integer rawCount;
+
+        @JsonProperty("spring_average_page_count")
+        private final Double springAveragePageCount;
+
+        @JsonProperty("raw_average_page_count")
+        private final Double rawAveragePageCount;
+
+        @JsonProperty("discard_average_page_count")
+        private final Double discardAveragePageCount;
+
+        @JsonProperty("spring_average_document_price")
+        private final Double springAverageDocumentPrice;
+
+        @JsonProperty("raw_average_document_price")
+        private final Double rawAverageDocumentPrice;
+
+        @JsonProperty("discard_average_document_price")
+        private final Double discardAverageDocumentPrice;
+
+        @Builder
+        public TotalStatisticsDto(Integer discardedCount, Integer springCount, Integer rawCount,
+                                  Double springAveragePageCount, Double rawAveragePageCount,
+                                  Double discardAveragePageCount,
+                                  Double springAverageDocumentPrice, Double rawAverageDocumentPrice,
+                                  Double discardAverageDocumentPrice) {
+            this.discardedCount = discardedCount;
+            this.springCount = springCount;
+            this.rawCount = rawCount;
+            this.springAveragePageCount =
+                    springAveragePageCount != null ? Math.round(springAveragePageCount * 10.0) / 10.0 : 0.0;
+            this.rawAveragePageCount =
+                    rawAveragePageCount != null ? Math.round(rawAveragePageCount * 10.0) / 10.0 : 0.0;
+            this.discardAveragePageCount =
+                    discardAveragePageCount != null ? Math.round(discardAveragePageCount * 10.0) / 10.0 : 0.0;
+            this.springAverageDocumentPrice =
+                    springAverageDocumentPrice != null ? Math.round(springAverageDocumentPrice * 10.0) / 10.0 : 0.0;
+            this.rawAverageDocumentPrice =
+                    rawAverageDocumentPrice != null ? Math.round(rawAverageDocumentPrice * 10.0) / 10.0 : 0.0;
+            this.discardAverageDocumentPrice =
+                    discardAverageDocumentPrice != null ? Math.round(discardAverageDocumentPrice * 10.0) / 10.0 : 0.0;
+        }
+    }
+
 }

--- a/src/main/java/com/tookscan/tookscan/order/repository/OrderRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/OrderRepository.java
@@ -83,7 +83,7 @@ public interface OrderRepository {
 
     Map<String, Map<ERecoveryOption, Double>> findMonthlyRecoveryOptionAveragePageCounts(LocalDateTime startDate, LocalDateTime endDate, Boolean isApplied, Boolean isArrived, Boolean isCompleted);
 
-    Map<String, Map<ERecoveryOption, Double>> findMonthlyRecoveryOptionAverageBookPrices(LocalDateTime startDate, LocalDateTime endDate, Boolean isApplied, Boolean isArrived, Boolean isCompleted);
+    Map<String, Map<ERecoveryOption, Double>> findMonthlyRecoveryOptionAverageDocumentPrices(LocalDateTime startDate, LocalDateTime endDate, Boolean isApplied, Boolean isArrived, Boolean isCompleted);
 
     Order findByIdWithDocumentsOrElseThrow(Long id);
 

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/OrderRepositoryImpl.java
@@ -525,7 +525,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Map<String, Map<ERecoveryOption, Double>> findMonthlyRecoveryOptionAverageBookPrices(LocalDateTime startDate, LocalDateTime endDate, Boolean isApplied, Boolean isArrived, Boolean isCompleted) {
+    public Map<String, Map<ERecoveryOption, Double>> findMonthlyRecoveryOptionAverageDocumentPrices(LocalDateTime startDate, LocalDateTime endDate, Boolean isApplied, Boolean isArrived, Boolean isCompleted) {
         QOrder order = QOrder.order;
         QDocument document = QDocument.document;
         


### PR DESCRIPTION
## Related issue 🛠
closed #698

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
관리자 페이지 통계 조회 응답값을 수정하였습니다.

### 주요 변경사항:
- **통계 조회 응답 구조 개선**: `ReadStatisticsSummariesResponseDto`에 새로운 통계 항목들 추가 및 구조화
- **Repository 메서드 시그니처 수정**: 통계 조회 관련 메서드의 매개변수 구조 변경  
- **서비스 레이어 로직 수정**: 통계 데이터 처리 로직 개선
- **사용자 정보 수정 기능 개선**: Account 엔티티에 성별 및 생년월일 필드 추가, 관련 DTO 및 서비스 로직 업데이트

### 변경된 파일:
- `ReadStatisticsSummariesResponseDto`: 통계 응답 구조 확장 (161줄 추가)
- `OrderRepository` & `OrderRepositoryImpl`: 통계 조회 메서드 시그니처 수정
- `ReadStatisticsSummariesService`: 통계 데이터 처리 로직 개선
- Account 관련 파일들: 사용자 정보 수정 기능 개선 (성별, 생년월일 필드 추가)

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 통계 조회 응답 구조가 크게 변경되었으므로 프론트엔드와의 API 스펙 확인이 필요합니다.
- Account 엔티티에 새로운 필드가 추가되었으므로 DB 마이그레이션 여부를 확인해주세요.
- 통계 관련 Repository 메서드의 성능에 대해 검토해주시면 감사하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 월별 통계 응답에 전체 합계 및 평균 정보를 제공하는 요약 통계(totalStatistics)가 추가되었습니다.

* **Refactor**
  * 월별 통계에서 "평균 도서 가격" 필드명이 "평균 문서 가격"으로 변경되었습니다.
  * 관련 필드, 메서드, 주석 등에서 "book price" 용어가 "document price"로 일괄 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->