### PR TITLE
🔨 Fix - HTTPS 환경에서 쿠키 삭제 실패 문제 해결

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/utility/CookieUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/CookieUtil.java
@@ -78,6 +78,7 @@ public class CookieUtil {
      *
      * @param request  HttpServletRequest
      * @param response HttpServletResponse
+     * @param cookieDomain Cookie 도메인
      * @param name     삭제할 Cookie 이름
      */
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String cookieDomain, String name) {
@@ -92,6 +93,8 @@ public class CookieUtil {
                         .path("/")
                         .maxAge(0)
                         .httpOnly(true)
+                        .secure(true)          // HTTPS 환경에서 쿠키 삭제를 위해 필요
+                        .sameSite("Lax")      // 생성시와 동일한 sameSite 설정
                         .build();
                 response.addHeader("Set-Cookie", removedCookie.toString());
             }


### PR DESCRIPTION
## Related issue 🛠
closed #702

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
HTTPS 환경에서 쿠키 삭제가 실패하는 문제를 해결했습니다.

### 문제 상황
- 로컬 환경(HTTP)에서는 쿠키 삭제가 정상 작동
- 프로덕션 환경(HTTPS)에서는 쿠키 삭제가 실패
- 로그아웃 시 토큰 쿠키들이 브라우저에 남아있음

### 원인 분석
`CookieUtil.deleteCookie()` 메서드에서 쿠키 삭제 시 필요한 보안 속성들이 누락:
- `secure` 속성 누락 (HTTPS 환경에서 필수)
- `sameSite` 속성 누락 (생성 시와 동일해야 함)

### 작업 내용
- **CookieUtil.deleteCookie() 메서드 수정**
  - `secure(true)` 속성 추가: HTTPS 환경에서 쿠키 삭제를 위해 필수
  - `sameSite("Lax")` 속성 추가: 생성 시와 동일한 정책 적용
  - 주석 추가로 수정 이유 명확화

### 기술적 배경
HTTP 쿠키 삭제 규칙에 따라 쿠키를 삭제하려면 생성 시와 정확히 동일한 속성으로 `maxAge=0`을 설정해야 합니다. 이전 구현에서는 `secure`와 `sameSite` 속성이 누락되어 HTTPS 환경에서 쿠키 삭제가 실패했습니다.

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 이 수정으로 인해 로컬 환경에서도 기존과 동일하게 작동합니다 (HTTP에서는 secure 속성이 무시됨)
- 프로덕션 환경에서는 이제 쿠키 삭제가 정상적으로 작동할 것입니다
- 쿠키 생성과 삭제 시의 속성 일치가 핵심 포인트입니다

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 쿠키 삭제 시 보안 속성(HTTPS 전용)과 SameSite 정책이 적용되어 일관성이 향상되었습니다.

* **문서화**
  * 쿠키 삭제 메서드의 설명이 업데이트되어 새로운 파라미터에 대한 안내가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->