### PR TITLE
🔨 Fix - 운영 및 개발 토큰 쿠키 이름 분리

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/utility/HttpServletUtil.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/HttpServletUtil.java
@@ -25,6 +25,15 @@ public class HttpServletUtil {
     @Value("${web-engine.cookie-domain}")
     private String cookieDomain;
 
+    @Value("${web-engine.cookie.access-token-name}")
+    private String accessTokenCookieName;
+
+    @Value("${web-engine.cookie.refresh-token-name}")
+    private String refreshTokenCookieName;
+
+    @Value("${web-engine.cookie.temporary-token-name}")
+    private String temporaryTokenCookieName;
+
     @Value("${json-web-token.refresh-token-expire-period}")
     private Long refreshTokenExpirePeriod;
 
@@ -44,14 +53,14 @@ public class HttpServletUtil {
             CookieUtil.addCookie(
                     response,
                     cookieDomain,
-                    Constants.ACCESS_TOKEN,
+                    accessTokenCookieName,
                     tokenDto.getAccessToken()
             );
 
             CookieUtil.addSecureCookie(
                     response,
                     cookieDomain,
-                    Constants.REFRESH_TOKEN,
+                    refreshTokenCookieName,
                     tokenDto.getRefreshToken(),
                     (int) (refreshTokenExpirePeriod / 1000L)
             );
@@ -61,7 +70,7 @@ public class HttpServletUtil {
             CookieUtil.addCookie(
                     response,
                     cookieDomain,
-                    Constants.TEMPORARY_TOKEN,
+                    temporaryTokenCookieName,
                     tokenDto.getTemporaryToken()
             );
         }
@@ -80,13 +89,13 @@ public class HttpServletUtil {
         CookieUtil.addCookie(
                 response,
                 cookieDomain,
-                Constants.ACCESS_TOKEN,
+                accessTokenCookieName,
                 tokenDto.getAccessToken()
         );
         CookieUtil.addSecureCookie(
                 response,
                 cookieDomain,
-                Constants.REFRESH_TOKEN,
+                refreshTokenCookieName,
                 tokenDto.getRefreshToken(),
                 (int) (refreshTokenExpirePeriod / 10000L) // 기존 기한의 10분의 1로 설정 (로그인 유지 체크 안함)
         );
@@ -111,13 +120,13 @@ public class HttpServletUtil {
         CookieUtil.addCookie(
                 response,
                 cookieDomain,
-                Constants.ACCESS_TOKEN,
+                accessTokenCookieName,
                 tokenDto.getAccessToken()
         );
         CookieUtil.addSecureCookie(
                 response,
                 cookieDomain,
-                Constants.REFRESH_TOKEN,
+                refreshTokenCookieName,
                 tokenDto.getRefreshToken(),
                 (int) (refreshTokenExpirePeriod / 1000L)
         );

--- a/src/main/java/com/tookscan/tookscan/security/config/SecurityConfig.java
+++ b/src/main/java/com/tookscan/tookscan/security/config/SecurityConfig.java
@@ -27,6 +27,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.beans.factory.annotation.Value;
 
 @Configuration
 @EnableWebSecurity
@@ -51,6 +52,15 @@ public class SecurityConfig {
     private final ReissueJsonWebTokenUseCase reissueJsonWebTokenUseCase;
 
     private final JsonWebTokenUtil jsonWebTokenUtil;
+
+    @Value("${web-engine.cookie-domain}")
+    private String cookieDomain;
+    @Value("${web-engine.cookie.access-token-name}")
+    private String accessTokenCookieName;
+    @Value("${web-engine.cookie.refresh-token-name}")
+    private String refreshTokenCookieName;
+    @Value("${web-engine.cookie.temporary-token-name}")
+    private String temporaryTokenCookieName;
 
     @Bean
     protected SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -102,7 +112,11 @@ public class SecurityConfig {
                                 authenticateJsonWebTokenUseCase,
                                 readAccountBriefUseCase,
                                 reissueJsonWebTokenUseCase,
-                                jsonWebTokenUtil
+                                jsonWebTokenUtil,
+                                cookieDomain,
+                                accessTokenCookieName,
+                                refreshTokenCookieName,
+                                temporaryTokenCookieName
                         ),
                         LogoutFilter.class
                 )

--- a/src/main/java/com/tookscan/tookscan/security/filter/GlobalLoggerFilter.java
+++ b/src/main/java/com/tookscan/tookscan/security/filter/GlobalLoggerFilter.java
@@ -6,11 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
+@RequiredArgsConstructor
 public class GlobalLoggerFilter extends OncePerRequestFilter {
 
     @Override

--- a/src/main/java/com/tookscan/tookscan/security/filter/JsonWebTokenAuthenticationFilter.java
+++ b/src/main/java/com/tookscan/tookscan/security/filter/JsonWebTokenAuthenticationFilter.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
@@ -41,8 +40,10 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
 
     private final JsonWebTokenUtil jsonWebTokenUtil;
 
-    @Value("${web-engine.cookie-domain}")
-    private String cookieDomain;
+    private final String cookieDomain;
+    private final String accessTokenCookieName;
+    private final String refreshTokenCookieName;
+    private final String temporaryTokenCookieName;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -54,11 +55,15 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+        System.out.println(cookieDomain);
+        System.out.println(accessTokenCookieName);
+        System.out.println(refreshTokenCookieName);
+        System.out.println(temporaryTokenCookieName);
 
         String requestURI = request.getRequestURI();
 
-        Optional<String> accessTokenOptional = CookieUtil.refineCookie(request, Constants.ACCESS_TOKEN);
-
+        Optional<String> accessTokenOptional = CookieUtil.refineCookie(request, accessTokenCookieName);
+        System.out.println(accessTokenOptional);
         if (AUTH_BRIEFS_URL.equals(requestURI)) {
             if (accessTokenOptional.isEmpty()) {
                 writeGuestResponse(response);
@@ -75,7 +80,7 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
                 if (e.getErrorCode() == ErrorCode.EXPIRED_TOKEN_ERROR) {
                     // 리프레시 토큰을 가져옵니다.
                     Optional<String> refreshTokenOptional = CookieUtil.refineCookie(request,
-                            Constants.REFRESH_TOKEN);
+                            refreshTokenCookieName);
                     if (refreshTokenOptional.isEmpty()) {
                         clearTokenCookies(request, response);
                         throw new HttpSecurityException(
@@ -89,9 +94,9 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
                     var newTokens = reissueJsonWebTokenUseCase.execute(refreshToken);
 
                     // 새로운 토큰으로 쿠키를 업데이트합니다.
-                    CookieUtil.addCookie(response, cookieDomain, Constants.ACCESS_TOKEN,
+                    CookieUtil.addCookie(response, cookieDomain, accessTokenCookieName,
                             newTokens.getAccessToken());
-                    CookieUtil.addSecureCookie(response, cookieDomain, Constants.REFRESH_TOKEN,
+                    CookieUtil.addSecureCookie(response, cookieDomain, refreshTokenCookieName,
                             newTokens.getRefreshToken(),
                             (int) (jsonWebTokenUtil.getRefreshTokenExpirePeriod() / 1000L));
 
@@ -201,7 +206,7 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
     private boolean tryRefreshToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         try {
-            Optional<String> refreshTokenOptional = CookieUtil.refineCookie(request, Constants.REFRESH_TOKEN);
+            Optional<String> refreshTokenOptional = CookieUtil.refineCookie(request, refreshTokenCookieName);
             if (refreshTokenOptional.isEmpty()) {
                 return false; // 리프레시 토큰이 없으면 재발급 불가
             }
@@ -211,8 +216,8 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
             var newTokens = reissueJsonWebTokenUseCase.execute(refreshToken);
 
             // 새로운 액세스 토큰으로 쿠키 설정
-            CookieUtil.addCookie(response, cookieDomain, Constants.ACCESS_TOKEN, newTokens.getAccessToken());
-            CookieUtil.addSecureCookie(response, cookieDomain, Constants.REFRESH_TOKEN, newTokens.getRefreshToken(),
+            CookieUtil.addCookie(response, cookieDomain, accessTokenCookieName, newTokens.getAccessToken());
+            CookieUtil.addSecureCookie(response, cookieDomain, refreshTokenCookieName, newTokens.getRefreshToken(),
                     (int) (jsonWebTokenUtil.getRefreshTokenExpirePeriod() / 1000L));
 
             // 새 액세스 토큰으로 인증 처리
@@ -249,9 +254,9 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
      * 토큰 관련 쿠키 삭제
      */
     private void clearTokenCookies(HttpServletRequest request, HttpServletResponse response) {
-        CookieUtil.deleteCookie(request, response, cookieDomain, Constants.ACCESS_TOKEN);
-        CookieUtil.deleteCookie(request, response, cookieDomain, Constants.REFRESH_TOKEN);
-        CookieUtil.deleteCookie(request, response, cookieDomain, Constants.TEMPORARY_TOKEN);
+        CookieUtil.deleteCookie(request, response, cookieDomain, accessTokenCookieName);
+        CookieUtil.deleteCookie(request, response, cookieDomain, refreshTokenCookieName);
+        CookieUtil.deleteCookie(request, response, cookieDomain, temporaryTokenCookieName);
     }
 
     @Override

--- a/src/main/java/com/tookscan/tookscan/security/filter/JsonWebTokenAuthenticationFilter.java
+++ b/src/main/java/com/tookscan/tookscan/security/filter/JsonWebTokenAuthenticationFilter.java
@@ -73,54 +73,43 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
                 return;
             } catch (HttpSecurityException e) {
                 if (e.getErrorCode() == ErrorCode.EXPIRED_TOKEN_ERROR) {
-                    try {
-                        // 리프레시 토큰을 가져옵니다.
-                        Optional<String> refreshTokenOptional = CookieUtil.refineCookie(request,
-                                Constants.REFRESH_TOKEN);
-                        if (refreshTokenOptional.isEmpty()) {
-                            // 리프레시 토큰이 없으면 재발급 불가, 게스트로 처리
-                            writeGuestResponse(response);
-                            return;
-                        }
-
-                        // 리프레시 토큰으로 새 토큰들을 발급받습니다.
-                        String refreshToken = refreshTokenOptional.get();
-                        var newTokens = reissueJsonWebTokenUseCase.execute(refreshToken);
-
-                        // 새로운 토큰으로 쿠키를 업데이트합니다.
-                        CookieUtil.addCookie(response, cookieDomain, Constants.ACCESS_TOKEN,
-                                newTokens.getAccessToken());
-                        CookieUtil.addSecureCookie(response, cookieDomain, Constants.REFRESH_TOKEN,
-                                newTokens.getRefreshToken(),
-                                (int) (jsonWebTokenUtil.getRefreshTokenExpirePeriod() / 1000L));
-
-                        // 재발급된 새 액세스 토큰으로 다시 계정 정보 조회를 시도합니다.
-                        Claims claims = jsonWebTokenUtil.validateToken(newTokens.getAccessToken());
-                        UUID accountId = UUID.fromString(claims.get(Constants.ACCOUNT_ID_CLAIM_NAME, String.class));
-                        ReadAccountBriefResponseDto responseDto = readAccountBriefUseCase.execute(accountId);
-                        writeAccountBriefResponse(response, responseDto);
-                        return;
-
-                    } catch (Exception refreshException) {
+                    // 리프레시 토큰을 가져옵니다.
+                    Optional<String> refreshTokenOptional = CookieUtil.refineCookie(request,
+                            Constants.REFRESH_TOKEN);
+                    if (refreshTokenOptional.isEmpty()) {
                         clearTokenCookies(request, response);
-                        writeGuestResponse(response);
-                        return;
+                        throw new HttpSecurityException(
+                                "리프레시 토큰이 없습니다. 다시 로그인해주세요.",
+                                ErrorCode.INVALID_TOKEN_ERROR
+                        );
                     }
-                } else if (isTokenInvalidError(e.getErrorCode())) {
-                    // 만료가 아닌 다른 종류의 토큰 오류일 경우 쿠키를 삭제합니다.
-                    clearTokenCookies(request, response);
-                }
-                // 처리되지 않은 예외는 그대로 던져서 전역 핸들러가 처리하도록 합니다.
-                throw e;
 
+                    // 리프레시 토큰으로 새 토큰들을 발급받습니다.
+                    String refreshToken = refreshTokenOptional.get();
+                    var newTokens = reissueJsonWebTokenUseCase.execute(refreshToken);
+
+                    // 새로운 토큰으로 쿠키를 업데이트합니다.
+                    CookieUtil.addCookie(response, cookieDomain, Constants.ACCESS_TOKEN,
+                            newTokens.getAccessToken());
+                    CookieUtil.addSecureCookie(response, cookieDomain, Constants.REFRESH_TOKEN,
+                            newTokens.getRefreshToken(),
+                            (int) (jsonWebTokenUtil.getRefreshTokenExpirePeriod() / 1000L));
+
+                    // 재발급된 새 액세스 토큰으로 다시 계정 정보 조회를 시도합니다.
+                    Claims claims = jsonWebTokenUtil.validateToken(newTokens.getAccessToken());
+                    UUID accountId = UUID.fromString(claims.get(Constants.ACCOUNT_ID_CLAIM_NAME, String.class));
+                    ReadAccountBriefResponseDto responseDto = readAccountBriefUseCase.execute(accountId);
+                    writeAccountBriefResponse(response, responseDto);
+                    return;
+                }
+                clearTokenCookies(request, response);
+                throw e;
             } catch (Exception e) {
-                // 기타 예외 발생 시 안전하게 게스트로 처리합니다.
-                writeGuestResponse(response);
-                return;
+                throw e;
             }
         }
 
-        String accessToken = accessTokenOptional.orElseThrow(() -> new CommonException(ErrorCode.INVALID_COOKIE_ERROR));
+        String accessToken = accessTokenOptional.orElseThrow(() -> new CommonException(ErrorCode.TOKEN_TYPE_ERROR));
 
         try {
             // 액세스 토큰 검증
@@ -158,12 +147,8 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
                 if (tryRefreshToken(request, response, filterChain)) {
                     return; // 재발급 성공 시 요청 계속 처리
                 }
-                // 재발급 실패 시 쿠키 삭제 후 401 반환 (리프레시 토큰도 만료됨)
-                clearTokenCookies(request, response);
-            } else if (isTokenInvalidError(e.getErrorCode())) {
-                // 유효하지 않은 토큰인 경우 쿠키 삭제
-                clearTokenCookies(request, response);
             }
+            clearTokenCookies(request, response);
             throw e;
         }
     }
@@ -268,17 +253,6 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
         CookieUtil.deleteCookie(request, response, cookieDomain, Constants.REFRESH_TOKEN);
         CookieUtil.deleteCookie(request, response, cookieDomain, Constants.TEMPORARY_TOKEN);
     }
-
-    /**
-     * 토큰이 유효하지 않은 오류인지 확인
-     */
-    private boolean isTokenInvalidError(ErrorCode errorCode) {
-        return errorCode == ErrorCode.TOKEN_MALFORMED_ERROR ||
-                errorCode == ErrorCode.TOKEN_TYPE_ERROR ||
-                errorCode == ErrorCode.TOKEN_UNSUPPORTED_ERROR ||
-                errorCode == ErrorCode.TOKEN_UNKNOWN_ERROR;
-    }
-
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {

--- a/src/main/java/com/tookscan/tookscan/security/handler/logout/DefaultLogoutSuccessHandler.java
+++ b/src/main/java/com/tookscan/tookscan/security/handler/logout/DefaultLogoutSuccessHandler.java
@@ -26,6 +26,15 @@ public class DefaultLogoutSuccessHandler
     @Value("${web-engine.cookie-domain}")
     private String cookieDomain;
 
+    @Value("${web-engine.cookie.access-token-name}")
+    private String accessTokenCookieName;
+
+    @Value("${web-engine.cookie.refresh-token-name}")
+    private String refreshTokenCookieName;
+
+    @Value("${web-engine.cookie.temporary-token-name}")
+    private String temporaryTokenCookieName;
+
     @Override
     public void onLogoutSuccess(
             HttpServletRequest request,
@@ -38,9 +47,9 @@ public class DefaultLogoutSuccessHandler
         }
 
 
-        CookieUtil.deleteCookie(request, response, cookieDomain, Constants.ACCESS_TOKEN);
-        CookieUtil.deleteCookie(request, response, cookieDomain, Constants.REFRESH_TOKEN);
-        CookieUtil.deleteCookie(request, response, cookieDomain, Constants.TEMPORARY_TOKEN);
+        CookieUtil.deleteCookie(request, response, cookieDomain, accessTokenCookieName);
+        CookieUtil.deleteCookie(request, response, cookieDomain, refreshTokenCookieName);
+        CookieUtil.deleteCookie(request, response, cookieDomain, temporaryTokenCookieName);
         CookieUtil.deleteCookie(request, response, cookieDomain, "JSESSIONID");
 
 

--- a/src/main/java/com/tookscan/tookscan/security/presentation/controller/AuthController.java
+++ b/src/main/java/com/tookscan/tookscan/security/presentation/controller/AuthController.java
@@ -45,6 +45,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -79,6 +80,12 @@ public class AuthController {
 
     private final HttpServletUtil httpServletUtil;
 
+    @Value("${web-engine.cookie.refresh-token-name}")
+    private String refreshTokenCookieName;
+
+    @Value("${web-engine.cookie.temporary-token-name}")
+    private String temporaryTokenCookieName;
+
     /**
      * 1.2.2 JWT 재발급
      */
@@ -99,7 +106,7 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response
     ) throws IOException {
-        String refreshToken = CookieUtil.refineCookie(request, Constants.REFRESH_TOKEN)
+        String refreshToken = CookieUtil.refineCookie(request, refreshTokenCookieName)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_COOKIE_ERROR));
 
         DefaultJsonWebTokenDto tokenDto = reissueJsonWebTokenUseCase.execute(refreshToken);
@@ -194,7 +201,7 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response
     ) throws IOException {
-        String temporaryToken = CookieUtil.refineCookie(request, Constants.TEMPORARY_TOKEN)
+        String temporaryToken = CookieUtil.refineCookie(request, temporaryTokenCookieName)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_COOKIE_ERROR));
 
         DefaultJsonWebTokenDto tokenDto = signUpOauthUseCase.execute(temporaryToken, requestDto);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,6 +144,10 @@ web-engine:
   server-url: ${WEB_ENGINE_SERVER_URL}
   client-url: ${WEB_ENGINE_CLIENT_URL}
   cookie-domain: ${WEB_ENGINE_COOKIE_DOMAIN}
+  cookie:
+    access-token-name: ${SPRING_PROFILES_ACTIVE}_access_token
+    refresh-token-name: ${SPRING_PROFILES_ACTIVE}_refresh_token
+    temporary-token-name: ${SPRING_PROFILES_ACTIVE}_temporary_token
 
 # === JWT (JSON Web Token) 공통 설정 ===
 json-web-token:


### PR DESCRIPTION
## Related issue 🛠
closed #716

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
### 주요 변경사항
- 운영과 개발 환경별로 토큰 쿠키 이름을 분리하여 환경 간 충돌 방지
- JWT 토큰 관련 서비스에서 하드코딩된 쿠키 이름을 환경별 설정으로 변경
- 쿠키 삭제 시 secure 및 sameSite 속성을 명시적으로 설정하여 HTTPS 환경에서 정상 동작하도록 개선

### 세부 수정 내용
1. **환경별 쿠키 이름 설정**
   - `CookieUtil`, `HttpServletUtil`, `SecurityConfig`에서 환경별 쿠키 이름 사용
   - `web-engine.cookie.access-token-name`, `refresh-token-name`, `temporary-token-name` 설정 활용

2. **쿠키 삭제 개선**
   - `CookieUtil.deleteCookie()` 메서드에서 `secure(true)`, `sameSite("Lax")` 설정 추가
   - HTTPS 환경에서 쿠키 삭제가 정상적으로 동작하도록 수정

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 쿠키 이름 분리로 인해 기존 로그인된 사용자들은 재로그인이 필요할 수 있습니다.
- 환경별 설정 파일(`application-{profile}.yml`)에 새로운 쿠키 이름 설정이 추가되어야 합니다.
- HTTPS 환경에서 쿠키 삭제 동작이 개선되었으므로 로그아웃 기능 테스트를 권장합니다.