### PR TITLE
🔨 Fix - 유저페이지 QA

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/application/service/CreateUserOrderService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/CreateUserOrderService.java
@@ -114,7 +114,7 @@ public class CreateUserOrderService implements CreateUserOrderUseCase {
                 .orderStatus(EOrderStatus.APPLY_COMPLETED)
                 .deliveryExpirationDate(
                         LocalDateTime.now().plusDays(DELIVERY_EXPIRATION_PERIOD).withHour(23).withMinute(59)
-                                .withSecond(59).withNano(999999999))
+                                .withSecond(59).withNano(0))
                 .scanCopyrightComplianceAgreed(LocalDateTime.now())
                 .illegalDistributionProhibitionAgreed(LocalDateTime.now())
                 .cuttingAgreed(LocalDateTime.now())

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/OrderService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/OrderService.java
@@ -150,7 +150,7 @@ public class OrderService {
 
     public void updatePaymentExpirationDate(Order order) {
         order.updatePaymentExpirationDate(
-                LocalDateTime.now().plusDays(DELIVERY_EXPIRATION_PERIOD).withHour(23).withMinute(59)
-                        .withSecond(59).withNano(999999999));
+                LocalDateTime.now().plusDays(PAYMENT_EXPIRATION_PERIOD).withHour(23).withMinute(59)
+                        .withSecond(59).withNano(0));
     }
 }


### PR DESCRIPTION
## Related issue 🛠
closed #724

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
마감기한 관련 버그를 수정했습니다.

### 수정 내용:
- 주문 생성 시 배송 만료 기한(deliveryExpirationDate)의 nano 값을 999999999에서 0으로 변경
- 결제 만료 기한(paymentExpirationDate) 업데이트 시 잘못된 상수 참조 수정 (DELIVERY_EXPIRATION_PERIOD → PAYMENT_EXPIRATION_PERIOD)
- 결제 만료 기한의 nano 값을 999999999에서 0으로 변경

### 수정 이유:
1. 마감기한에서 nano초까지 포함되어 정확한 23:59:59 시간이 아닌 상태였음
2. 결제 만료 기한 계산에서 잘못된 상수를 참조하여 의도와 다른 기간이 설정되었음

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 마감기한 관련 로직에서 nano초 제거를 통한 정확한 시간 설정 확인 부탁드립니다.
- 결제 만료 기한 계산에서 올바른 상수 사용 여부 확인 부탁드립니다.
- 기존 데이터에 영향을 주지 않는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 주문 및 결제 만료 시간이 더 이상 23:59:59.999999999가 아닌 23:59:59.000000000로 정확하게 설정됩니다.  
  * 결제 만료일 계산 시 적용되는 기간이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->