### PR TITLE
🔨 Fix - 모든 PDF 업로드 완료 상태일 경우에만 발송 가능하도록 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/exception/error/ErrorCode.java
+++ b/src/main/java/com/tookscan/tookscan/core/exception/error/ErrorCode.java
@@ -98,6 +98,7 @@ public enum ErrorCode {
     EXCEEDED_MAX_USED_COUPON_PER_USER(40059, HttpStatus.BAD_REQUEST, "한 유저 당 사용 가능한 해당 쿠폰의 사용 횟수를 초과했습니다."),
     EXCEEDED_MAX_USED_COUPON(40060, HttpStatus.BAD_REQUEST, "해당 쿠폰의 전체 사용 횟수를 초과했습니다."),
     NOT_ENOUGH_ORDER_PRICE_FOR_COUPON(40061, HttpStatus.BAD_REQUEST, "쿠폰을 사용하기 위한 최소 주문 금액이 충족되지 않았습니다. 주문 취소 후 다시 진행해주세요."),
+    NOT_PDF_UPLOADED(40063, HttpStatus.BAD_REQUEST, "PDF 파일이 업로드되지 않았습니다."),
 
     // Conflict Error
     DUPLICATE_COUPON_CODE(40900, HttpStatus.CONFLICT, "이미 존재하는 쿠폰 코드입니다."),

--- a/src/main/java/com/tookscan/tookscan/order/application/service/OrderStatusUpdateService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/OrderStatusUpdateService.java
@@ -3,7 +3,10 @@ package com.tookscan.tookscan.order.application.service;
 import com.tookscan.tookscan.order.application.usecase.UpdateOrderStatusAfterPdfProcessingUseCase;
 import com.tookscan.tookscan.order.domain.Order;
 import com.tookscan.tookscan.order.domain.service.OrderService;
+import com.tookscan.tookscan.order.domain.type.EOrderStatus;
 import com.tookscan.tookscan.order.repository.OrderRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +26,17 @@ public class OrderStatusUpdateService implements UpdateOrderStatusAfterPdfProces
     public void execute(Long orderId) {
         try {
             Order order = orderRepository.findByIdOrElseThrow(orderId);
+
+            List<EOrderStatus> validStatuses = List.of(
+                    EOrderStatus.RECOVERY_IN_PROGRESS,
+                    EOrderStatus.POST_WAITING,
+                    EOrderStatus.ALL_COMPLETED
+            );
+
+            if (validStatuses.contains(order.getOrderStatus())) {
+                order.updateScanCompletedAt(LocalDateTime.now());
+                return;
+            }
 
             boolean hasAnyPdf = order.getDocuments().stream().anyMatch(doc -> !doc.getPdfs().isEmpty());
             boolean allDocumentsHavePdf = order.getDocuments().stream().noneMatch(doc -> doc.getPdfs().isEmpty());

--- a/src/main/java/com/tookscan/tookscan/order/application/service/SendAdminPdfService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/SendAdminPdfService.java
@@ -12,6 +12,8 @@ import com.tookscan.tookscan.order.domain.Document;
 import com.tookscan.tookscan.order.domain.Order;
 import com.tookscan.tookscan.order.domain.Pdf;
 import com.tookscan.tookscan.order.domain.service.OrderService;
+import com.tookscan.tookscan.order.domain.type.EOrderStatus;
+import com.tookscan.tookscan.order.domain.type.EPdfUploadStatus;
 import com.tookscan.tookscan.order.domain.type.ERecoveryOption;
 import com.tookscan.tookscan.order.repository.OrderRepository;
 import java.time.LocalDateTime;
@@ -44,6 +46,16 @@ public class SendAdminPdfService implements SendAdminPdfUseCase {
 
         Order order = orderRepository.findByIdWithDocumentsAndDeliveryOrElseThrow(orderId);
 
+        // 주문 상태 검증
+        List<EOrderStatus> validStatuses = List.of(
+                EOrderStatus.SCAN_COMPLETED,
+                EOrderStatus.RECOVERY_IN_PROGRESS,
+                EOrderStatus.POST_WAITING,
+                EOrderStatus.ALL_COMPLETED
+        );
+
+        orderService.validateOrderStatuses(order, validStatuses, ErrorCode.INVALID_ORDER_STATUS);
+
         // 스캔 완료 알림 메시지 이벤트 발행
         applicationEventPublisher.publishEvent(
                 AnnounceScanFinishMessageEvent.of(
@@ -63,8 +75,12 @@ public class SendAdminPdfService implements SendAdminPdfUseCase {
             if (document.getPdfs().isEmpty()) {
                 throw new CommonException(ErrorCode.NOT_FOUND_PDF);
             }
+
             // PDF 파일이 S3에 저장되어 있는지 확인
             for (Pdf pdf : document.getPdfs()) {
+                if (pdf.getUploadStatus() != EPdfUploadStatus.COMPLETED) {
+                    throw new CommonException(ErrorCode.NOT_PDF_UPLOADED);
+                }
                 pdf.updatePdfUrlForUser(s3Util.getSignedUrlForUser(pdf));
             }
         }
@@ -83,16 +99,26 @@ public class SendAdminPdfService implements SendAdminPdfUseCase {
 
         order.updatePdfSendDate(LocalDateTime.now());
 
+        List<EOrderStatus> expectedStatuses = List.of(
+                EOrderStatus.RECOVERY_IN_PROGRESS,
+                EOrderStatus.POST_WAITING,
+                EOrderStatus.ALL_COMPLETED
+        );
+
+        if (expectedStatuses.contains(order.getOrderStatus())) {
+            orderRepository.save(order);
+            LogContext.put("order_id", orderId);
+            return;
+        }
+
         // 이후 배송할일이 없다면(모든 문서가 폐기라면)
         if (order.getDocuments().stream()
                 .noneMatch(document -> document.getRecoveryOption() != ERecoveryOption.DISCARD)) {
             orderService.allComplete(order);
-            orderRepository.save(order);
         } else {
             orderService.startRecovery(order);
-            orderRepository.save(order);
         }
-        
+        orderRepository.save(order);
         LogContext.put("order_id", orderId);
     }
 }

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UploadAdminDocumentsPdfService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UploadAdminDocumentsPdfService.java
@@ -4,6 +4,7 @@ import com.tookscan.tookscan.account.domain.User;
 import com.tookscan.tookscan.account.repository.UserRepository;
 import com.tookscan.tookscan.core.annotation.BusinessLog;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.core.util.LogContext;
 import com.tookscan.tookscan.core.utility.DateTimeUtil;
 import com.tookscan.tookscan.order.application.usecase.UploadAdminDocumentsPdfUseCase;
@@ -100,7 +101,10 @@ public class UploadAdminDocumentsPdfService implements UploadAdminDocumentsPdfUs
         List<EOrderStatus> validStatuses = List.of(
                 EOrderStatus.PAYMENT_COMPLETED,
                 EOrderStatus.SCAN_IN_PROGRESS,
-                EOrderStatus.SCAN_COMPLETED
+                EOrderStatus.SCAN_COMPLETED,
+                EOrderStatus.RECOVERY_IN_PROGRESS,
+                EOrderStatus.POST_WAITING,
+                EOrderStatus.ALL_COMPLETED
         );
 
         orderService.validateOrderStatuses(order, validStatuses, ErrorCode.INVALID_ORDER_STATUS);
@@ -111,7 +115,7 @@ public class UploadAdminDocumentsPdfService implements UploadAdminDocumentsPdfUs
         String orderNumber = order.getOrderNumber();
         String orderCreatedAt = DateTimeUtil.convertLocalDateTimeToDartString(order.getCreatedAt());
 
-        // 4. 요청 내 중복 파일명 선제 차단 (for문 전에 전체 검사) + 파일 객체 보관
+        // 4. 요청 내 중복 파일명 선제 차단 (for문 전에 전체 검사) + 기존 문서와의 중복 배치 검증 + 파일 객체 보관
         Set<String> requestDuplicateGuard = new HashSet<>();
         List<PreparedUploadFile> preparedFiles = new ArrayList<>(files.size());
         for (MultipartFile file : files) {
@@ -120,10 +124,13 @@ public class UploadAdminDocumentsPdfService implements UploadAdminDocumentsPdfUs
                 originalFileName = "unnamed.pdf";
             }
             if (!requestDuplicateGuard.add(originalFileName)) {
-                throw new RuntimeException("동일 요청 내에서 중복된 파일명이 존재합니다: " + originalFileName);
+                throw new CommonException(ErrorCode.DUPLICATE_PDF_FILENAME, "중복된 파일명이 감지되었습니다: " + originalFileName);
             }
             preparedFiles.add(new PreparedUploadFile(originalFileName, file));
         }
+
+        // 기존 문서의 PDF 파일명과의 중복을 일괄 검증
+        pdfService.validateUniqueFilenames(document, requestDuplicateGuard);
 
         List<Pdf> pdfs = new ArrayList<>();
 
@@ -132,9 +139,6 @@ public class UploadAdminDocumentsPdfService implements UploadAdminDocumentsPdfUs
             String originalFileName = prepared.getOriginalFileName();
             MultipartFile file = prepared.getFile();
             try {
-                // 파일명 중복 검증 (메인 트랜잭션에서)
-                pdfService.validateUniqueFilename(document, originalFileName);
-
                 // S3에 저장할 고유 파일명 생성
                 String extension = StringUtils.getFilenameExtension(originalFileName);
                 if (extension == null || extension.isBlank()) {

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/PdfService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/PdfService.java
@@ -5,6 +5,7 @@ import com.tookscan.tookscan.core.exception.type.CommonException;
 import com.tookscan.tookscan.order.domain.Document;
 import com.tookscan.tookscan.order.domain.Pdf;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,27 @@ public class PdfService {
         // 파일명이 중복되면 예외 발생
         if (existingFilenames.contains(fileName)) {
             throw new CommonException(ErrorCode.DUPLICATE_PDF_FILENAME, "파일명: " + fileName);
+        }
+    }
+
+    /**
+     * Document 내에서 다수의 파일명 중복을 한 번에 확인합니다.
+     * 하나라도 중복되면 예외를 던집니다.
+     *
+     * @param document  Document 객체
+     * @param fileNames 요청에서 전달된 파일명 집합
+     * @throws CommonException 중복된 파일명이 하나라도 존재할 경우
+     */
+    public void validateUniqueFilenames(Document document, Iterable<String> fileNames) {
+        Set<String> existingFilenames = document.getPdfs().stream()
+                .map(Pdf::getName)
+                .collect(Collectors.toSet());
+
+        boolean hasDuplicate = StreamSupport.stream(fileNames.spliterator(), false)
+                .anyMatch(existingFilenames::contains);
+
+        if (hasDuplicate) {
+            throw new CommonException(ErrorCode.DUPLICATE_PDF_FILENAME, "기존 문서와 중복된 파일명이 포함되어 있습니다.");
         }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
closed #747

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
PDF 발송 프로세스에서 안정성을 개선하여 모든 PDF 업로드가 완료된 상태에서만 발송이 가능하도록 수정하였습니다.

### 주요 변경 사항
- `PdfService.areAllPdfsUploaded()` 메서드 추가: 주문의 모든 PDF 업로드 완료 상태를 검증하는 로직
- `SendAdminPdfService`: PDF 발송 전 업로드 완료 상태 검증 로직 추가
- `UploadAdminDocumentsPdfService`: PDF 업로드 프로세스 개선
- `OrderStatusUpdateService`: 주문 상태 업데이트 시 PDF 상태 검증 강화
- `ErrorCode`: PDF 발송 관련 에러 코드 추가

### 기술적 개선 사항
- PDF 업로드 상태를 엄격하게 검증하여 불완전한 상태에서의 발송 방지
- 에러 핸들링 개선으로 사용자에게 명확한 피드백 제공
- 주문 프로세스의 안정성 및 신뢰성 향상

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- PDF 업로드와 발송 프로세스 간의 의존성을 강화한 변경사항입니다.
- `PdfService.areAllPdfsUploaded()` 메서드의 로직을 중점적으로 검토해주세요.
- 기존 PDF 처리 흐름에 미치는 영향을 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * PDF 미업로드 시 명확한 오류 코드와 메시지 제공.
  * 일괄 중복 파일명 검사 도입으로 교차 문서 중복까지 사전 방지.
* Bug Fixes
  * 관리자 PDF 업로드 중 중복 파일명을 일관된 오류로 반환.
  * 특정 주문 상태에서 잘못된 스캔/복구 로직 진입 방지.
* Refactor
  * 주문 상태 검증 범위 확장으로 관리자 업로드/전송 흐름 안정화.
  * 저장 절차 정리로 중복 저장 제거 및 로깅 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->