### PR TITLE
🔨 Fix - pdf 진행상태 조회 엔드포인트 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
@@ -4,7 +4,6 @@ import com.tookscan.tookscan.core.annotation.swagger.ApiErrorCode;
 import com.tookscan.tookscan.core.dto.ResponseDto;
 import com.tookscan.tookscan.core.exception.error.ErrorCode;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminCouponTemplateDetailUseCase;
-import com.tookscan.tookscan.order.application.usecase.SubscribePdfProgressUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminCouponTemplateOverviewUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminDocumentsPdfsUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminIssuedCouponOverviewUseCase;
@@ -13,6 +12,7 @@ import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderDetailUseCa
 import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderOverviewsUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminUsedCouponOverviewUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadStatisticsSummariesUseCase;
+import com.tookscan.tookscan.order.application.usecase.SubscribePdfProgressUseCase;
 import com.tookscan.tookscan.order.domain.type.ECouponFormat;
 import com.tookscan.tookscan.order.domain.type.ECouponType;
 import com.tookscan.tookscan.order.domain.type.EOrderStatus;
@@ -29,16 +29,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.util.UUID;
 
 @Tag(name = "Order", description = "Order 관련 API 입니다.")
 @RestController
@@ -219,7 +219,7 @@ public class OrderAdminQueryV1Controller {
 
     @Operation(summary = "관리자용 PDF 업로드 진행 SSE", description = "관리자가 주문/문서 단위 업로드 진행 이벤트를 수신합니다.")
     @ApiErrorCode({})
-    @GetMapping(value = "/orders/pdfs/{pdfId}/progress", produces = "text/event-stream")
+    @GetMapping(value = "/orders/pdfs/{pdfId}/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribePdfProgress(@PathVariable Long pdfId) {
         return subscribePdfProgressUseCase.execute(pdfId);
     }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #749 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- pdf 진행상태 조회 엔드포인트 수정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - SSE PDF 진행 상태 구독 엔드포인트 경로를 GET /orders/pdfs/{pdfId}/progress에서 GET /orders/pdfs/{pdfId}/subscribe로 변경했습니다. 해당 API를 사용하는 클라이언트는 경로를 업데이트하세요.
  - 응답 콘텐츠 타입을 상수 기반으로 표준화했습니다(text/event-stream). 기능 동작은 동일합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->