### PR TITLE
🔨 Fix - PDF 진행상태조회 AUTH 제외

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/constant/Constants.java
+++ b/src/main/java/com/tookscan/tookscan/core/constant/Constants.java
@@ -72,7 +72,7 @@ public class Constants {
             "/actuator/health",
 
             // SSE
-            "/v1/admins/orders/pdfs/*/subscribe"
+            "/v1/admins/orders/pdfs/{pdfId}/subscribe"
     );
 
     /**

--- a/src/main/java/com/tookscan/tookscan/security/filter/JsonWebTokenAuthenticationFilter.java
+++ b/src/main/java/com/tookscan/tookscan/security/filter/JsonWebTokenAuthenticationFilter.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.util.AntPathMatcher;
 
 @RequiredArgsConstructor
 public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
@@ -258,9 +259,14 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
 
-        // 인증이 필요 없는 URL 목록에 포함되는지 확인
-        return Constants.NO_NEED_AUTH_URLS.stream()
-                .anyMatch(excludePattern -> requestURI.matches(excludePattern.replace("**", ".*")));
+        AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+        // 인증이 필요 없는 URL 목록에 포함되는지 확인 (Ant 패턴 + {var} 지원)
+        return Constants.NO_NEED_AUTH_URLS.stream().anyMatch(pattern -> {
+            // PathPattern 스타일의 {variable}을 Ant 패턴의 * 로 정규화
+            String normalized = pattern.replaceAll("\\{[^/]+}", "*");
+            return antPathMatcher.match(normalized, requestURI);
+        });
     }
 }
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #770 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- PDF 진행상태조회 AUTH 제외

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 해당 없음
- 버그 수정
  - 주문 PDF 구독 엔드포인트의 비인증 접근 판단을 개선해 특정 PDF ID에 한해 올바르게 동작하도록 수정했습니다. 예외적으로 인증이 필요하거나 불필요한 상황을 해소했습니다.
- 리팩터
  - 인증 필터의 URL 패턴 매칭을 보다 견고한 방식으로 전환해 경로 변수와 와일드카드 처리의 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->