### PR TITLE
🔨 Fix - 가격 계산 API 응답값 OCR 가격, OnedayScan 가격 추가

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/domain/Document.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/Document.java
@@ -154,5 +154,13 @@ public class Document extends BaseEntity {
 
         return pageCount * additionalPriceForOcr;
     }
+
+    public int getEstimatedOcrPrice() {
+        return pageCount * additionalPriceForOcr;
+    }
+
+    public int getEstimatedOneDayScanPrice() {
+        return pageCount * order.getAdditionalPriceForOneDayScan();
+    }
 }
 

--- a/src/main/java/com/tookscan/tookscan/order/domain/service/DocumentService.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/service/DocumentService.java
@@ -58,13 +58,14 @@ public class DocumentService {
 
     private int calculateRecoveryOptionPrice(int pageCount, ERecoveryOption recoveryOption) {
         if (recoveryOption == ERecoveryOption.SPRING) {
-            int basePrice = 3000; // 300페이지까지 기본 3,000원
-            if (pageCount <= 300) {
+            int basePrice = 3000; // 400페이지까지 기본 3,000원
+            if (pageCount <= 400) {
                 return basePrice;
             }
-            int extraPages = pageCount - 300;
-            int increments = (int) Math.ceil(extraPages / 100.0); // 100페이지당 1,000원 (올림)
-            return basePrice + (increments * 1000);
+            // 이후 300페이지 단위로 3,000원씩 추가
+            int extraPages = pageCount - 400;
+            int increments = (int) Math.ceil(extraPages / 300.0); // 300페이지당 3,000원 (올림)
+            return basePrice + (increments * 3000);
         }
         // 기타 옵션은 고정가(현재 0원)
         return recoveryOption.getPrice();

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/EstimateUserOrderPriceResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/EstimateUserOrderPriceResponseDto.java
@@ -49,6 +49,12 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
     @JsonProperty("payment_total")
     private final Integer paymentTotal;
 
+    @JsonProperty("estimated_ocr_price")
+    private final Integer estimatedOcrPrice;
+
+    @JsonProperty("estimated_one_day_scan_price")
+    private final Integer estimatedOneDayScanPrice;
+
     @Getter
     @Valid
     public static class DocumentInfoDto extends SelfValidating<DocumentInfoDto> {
@@ -88,6 +94,14 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
         @NotNull
         private final Integer cuttingPrice;
 
+        @JsonProperty("estimated_ocr_price")
+        @NotNull
+        private final Integer estimatedOcrPrice;
+
+        @JsonProperty("estimated_one_day_scan_price")
+        @NotNull
+        private final Integer estimatedOneDayScanPrice;
+
         @Builder
         public DocumentInfoDto(String name,
                                Integer pageCount,
@@ -97,7 +111,9 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
                                Integer recoveryPrice,
                                Integer oneDayScanPrice,
                                Integer cuttingPrice,
-                               Integer ocrPrice) {
+                               Integer ocrPrice,
+                               Integer estimatedOcrPrice,
+                               Integer estimatedOneDayScanPrice) {
             this.name = name;
             this.pageCount = pageCount;
             this.pagePrice = pagePrice;
@@ -107,6 +123,8 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
             this.oneDayScanPrice = oneDayScanPrice;
             this.ocrPrice = ocrPrice;
             this.cuttingPrice = cuttingPrice;
+            this.estimatedOcrPrice = estimatedOcrPrice;
+            this.estimatedOneDayScanPrice = estimatedOneDayScanPrice;
             this.validateSelf();
         }
 
@@ -121,6 +139,8 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
                     .oneDayScanPrice(document.getOneDayScanPrice())
                     .ocrPrice(document.getOcrPrice())
                     .cuttingPrice(document.getCuttingPrice())
+                    .estimatedOcrPrice(document.getEstimatedOcrPrice())
+                    .estimatedOneDayScanPrice(document.getEstimatedOneDayScanPrice())
                     .build();
         }
     }
@@ -137,7 +157,9 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
             Integer couponPrice,
             Integer couponPercentage,
             Integer paymentTotal,
-            Integer ocrPrice
+            Integer ocrPrice,
+            Integer estimatedOcrPrice,
+            Integer estimatedOneDayScanPrice
     ) {
         this.documents = documents;
         this.documentsPrice = documentsPrice;
@@ -150,6 +172,8 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
         this.couponPercentage = couponPercentage;
         this.paymentTotal = paymentTotal;
         this.ocrPrice = ocrPrice;
+        this.estimatedOcrPrice = estimatedOcrPrice;
+        this.estimatedOneDayScanPrice = estimatedOneDayScanPrice;
         this.validateSelf();
     }
 
@@ -182,6 +206,12 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
         int recoveryPriceSum = checkedDocs.stream()
                 .mapToInt(DocumentInfoDto::getRecoveryPrice)
                 .sum();
+        int estimatedOcrPriceSum = checkedDocs.stream()
+                .mapToInt(DocumentInfoDto::getEstimatedOcrPrice)
+                .sum();
+        int estimatedOneDayScanPriceSum = checkedDocs.stream()
+                .mapToInt(DocumentInfoDto::getEstimatedOneDayScanPrice)
+                .sum();
 
         return EstimateUserOrderPriceResponseDto.builder()
                 .documents(allDocs)
@@ -193,6 +223,8 @@ public class EstimateUserOrderPriceResponseDto extends SelfValidating<EstimateUs
                 .deliveryPrice(order.getDelivery().getDeliveryPrice())
                 .recoveryPrice(recoveryPriceSum)
                 .cuttingPrice(cuttingPriceSum)
+                .estimatedOcrPrice(estimatedOcrPriceSum)
+                .estimatedOneDayScanPrice(estimatedOneDayScanPriceSum)
                 .couponPrice(order.getUsedCoupon() != null ? order.getUsedCoupon().getIssuedCoupon().getDiscountPrice(order.getDocumentsTotalAmount(), ocrPriceSum, order.getDelivery().getDeliveryPrice()) : 0)
                 .paymentTotal(order.getTotalAmount())
                 .build();


### PR DESCRIPTION
## Related issue 🛠
closed #782

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
가격 계산 API 응답값에 OCR 가격과 OnedayScan 가격 정보를 추가했습니다.

### 주요 변경사항
- **EstimateUserOrderPriceResponseDto**: `estimated_ocr_price`, `estimated_one_day_scan_price` 필드 추가
- **Document 엔티티**: `getEstimatedOcrPrice()`, `getEstimatedOneDayScanPrice()` 메서드 추가
- **DocumentService**: 제본 옵션 가격 계산 로직 수정 (400페이지까지 기본 3,000원, 이후 300페이지당 3,000원)

### 기능 개선사항
- 가격 견적 API에서 예상 OCR 비용과 당일 스캔 비용을 별도로 제공하여 사용자가 옵션별 비용을 더 명확하게 파악할 수 있도록 개선
- 제본 옵션 가격 정책 변경으로 더 합리적인 요금 체계 적용

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 가격 계산 로직의 변경사항을 확인해 주세요 (제본 옵션 가격 정책)
- 새로 추가된 예상 가격 필드들이 올바르게 계산되는지 검토해 주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 가격 견적 응답에 예상 OCR 비용과 당일 스캔 예상 비용을 추가했습니다. 문서별 항목과 전체 합계가 함께 제공됩니다.
  - SPRING 복구 옵션의 가격 규칙을 조정했습니다: 기본 포함 분량을 400페이지로 확대하고, 초과분은 300페이지당 3,000원 단위로 계산됩니다.

- 기타
  - 내부 계산 로직을 최신 규칙에 맞게 정리하고 주석을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->