### PR TITLE
🔨 Fix - 유저 쿠폰 상세 조회에 유효기간 및 description 필드 추가

### DIFF
--- a/http/auth/AuthControllerHttpRequest.http
+++ b/http/auth/AuthControllerHttpRequest.http
@@ -46,7 +46,7 @@ Content-Type: application/json
     "is_receive_email" : true,
     "is_receive_sms" : true,
     "gender": "MALE",
-    "birth": "2000-04-04"
+    "birth": 2000
 }
 
 ### 2.1.5 회원 정보 검증
@@ -75,7 +75,7 @@ GET {{host_url}}/v1/auth/existence/phone-number?phone-number=01012341234
 
 ### 2.3.1 휴대폰 인증번호 검증
 // @no-log
-@authentication_code = "880675"
+@authentication_code = "368968"
 PATCH {{host_url}}/v1/auth/authentication-code
 Content-Type: application/json
 

--- a/http/order/OrderControllerHttpRequest.http
+++ b/http/order/OrderControllerHttpRequest.http
@@ -156,3 +156,8 @@ POST {{host_url}}/v1/admins/coupon-templates/738696461221983066/used-coupons/exp
 ### 비회원 주문 조회
 //@no-log
 GET {{host_url}}/v1/guests/orders/0MG33RRV7JWVA/details
+
+
+### 쿠폰 조회
+//@no-log
+GET {{host_url}}/v1/users/orders/coupon/detail?coupon-code=TOOK081220

--- a/src/main/java/com/tookscan/tookscan/order/application/service/ReadUserOrderCouponDetailService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ReadUserOrderCouponDetailService.java
@@ -24,7 +24,7 @@ public class ReadUserOrderCouponDetailService implements ReadUserOrderCouponDeta
     @Override
     @Transactional(readOnly = true)
     public ReadUserOrderCouponDetailResponseDto execute(UUID accountId, String couponCode) {
-        IssuedCoupon issuedCoupon = issuedCouponRepository.findByCodeOrElseThrow(couponCode);
+        IssuedCoupon issuedCoupon = issuedCouponRepository.findWithCouponTemplateByCodeOrElseThrow(couponCode);
         this.validateCouponExpiration(accountId, issuedCoupon);
         return ReadUserOrderCouponDetailResponseDto.fromEntity(issuedCoupon);
     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderCouponDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadUserOrderCouponDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.tookscan.tookscan.order.presentation.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tookscan.tookscan.core.dto.SelfValidating;
+import com.tookscan.tookscan.core.utility.DateTimeUtil;
 import com.tookscan.tookscan.order.domain.CouponTemplate;
 import com.tookscan.tookscan.order.domain.IssuedCoupon;
 import com.tookscan.tookscan.order.domain.type.ECouponType;
@@ -18,6 +19,12 @@ public class ReadUserOrderCouponDetailResponseDto extends SelfValidating<ReadUse
     @JsonProperty("description")
     private final String description;
 
+    @JsonProperty("start_date")
+    private final String startDate;
+
+    @JsonProperty("end_date")
+    private final String endDate;
+
     @JsonProperty("type")
     private final ECouponType type;
 
@@ -28,11 +35,13 @@ public class ReadUserOrderCouponDetailResponseDto extends SelfValidating<ReadUse
     private final Integer discountPercent;
 
     @Builder
-    public ReadUserOrderCouponDetailResponseDto(String id, String name, String description, ECouponType type,
+    public ReadUserOrderCouponDetailResponseDto(String id, String name, String description, String startDate, String endDate, ECouponType type,
                                                 Integer discountPrice, Integer discountPercent) {
         this.id = id;
         this.name = name;
         this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.type = type;
         this.discountPrice = discountPrice;
         this.discountPercent = discountPercent;
@@ -40,9 +49,51 @@ public class ReadUserOrderCouponDetailResponseDto extends SelfValidating<ReadUse
     }
 
     public static ReadUserOrderCouponDetailResponseDto fromEntity(IssuedCoupon issuedCoupon) {
+
+        String description = null;
+        CouponTemplate couponTemplate = issuedCoupon.getCouponTemplate();
+
+        if (couponTemplate.getType().equals(ECouponType.PERCENTAGE)) {
+            int percent = couponTemplate.getDiscountPercent();
+            Integer minPrice = couponTemplate.getMinOrderPrice();
+            Integer maxPrice = couponTemplate.getMaxDiscountPrice();
+
+            if (minPrice != null && maxPrice != null) {
+                description = String.format("%d%% 할인 (%d원 이상 / 최대 %d원)", percent, minPrice, maxPrice);
+            } else if (maxPrice != null) {
+                description = String.format("%d%% 할인 (최대 %d원)", percent, maxPrice);
+            } else if (minPrice != null) {
+                description = String.format("%d%% 할인 (%d원 이상)", percent, minPrice);
+            } else {
+                description = String.format("%d%% 할인", percent);
+            }
+
+        } else if (couponTemplate.getType().equals(ECouponType.AMOUNT)) {
+            int amount = couponTemplate.getDiscountPrice();
+            Integer minPrice = couponTemplate.getMinOrderPrice();
+            Integer maxPrice = couponTemplate.getMaxDiscountPrice();
+
+            if (minPrice != null && maxPrice != null) {
+                description = String.format("%d원 할인 (%d원 이상 / 최대 %d원)", amount, minPrice, maxPrice);
+            } else if (maxPrice != null) {
+                description = String.format("%d원 할인 (최대 %d원)", amount, maxPrice);
+            } else if (minPrice != null) {
+                description = String.format("%d원 할인 (%d원 이상)", amount, minPrice);
+            } else {
+                description = String.format("%d원 할인", amount);
+            }
+        } else if (couponTemplate.getType().equals(ECouponType.OCR_FREE)) {
+            description = ECouponType.OCR_FREE.getDescription();
+        } else if (couponTemplate.getType().equals(ECouponType.DELIVERY_PRICE_FREE)) {
+            description = ECouponType.DELIVERY_PRICE_FREE.getDescription();
+        }
+
         return ReadUserOrderCouponDetailResponseDto.builder()
                 .id(issuedCoupon.getId().toString())
                 .name(issuedCoupon.getCouponTemplate().getName())
+                .description(description)
+                .startDate(issuedCoupon.getCouponTemplate().getStartDateTime() != null ? DateTimeUtil.convertLocalDateToDartString(issuedCoupon.getCouponTemplate().getStartDateTime().toLocalDate()) : null)
+                .endDate(issuedCoupon.getCouponTemplate().getEndDateTime() != null ? DateTimeUtil.convertLocalDateToDartString(issuedCoupon.getCouponTemplate().getEndDateTime().toLocalDate()) : null)
                 .type(issuedCoupon.getCouponTemplate().getType())
                 .discountPrice(issuedCoupon.getCouponTemplate().getDiscountPrice())
                 .discountPercent(issuedCoupon.getCouponTemplate().getDiscountPercent())

--- a/src/main/java/com/tookscan/tookscan/order/repository/IssuedCouponRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/IssuedCouponRepository.java
@@ -10,7 +10,7 @@ public interface IssuedCouponRepository {
 
     IssuedCoupon findByIdOrElseThrow(Long id);
 
-    IssuedCoupon findByCodeOrElseThrow(String couponCode);
+    IssuedCoupon findWithCouponTemplateByCodeOrElseThrow(String couponCode);
 
     void save(IssuedCoupon issuedCoupon);
 

--- a/src/main/java/com/tookscan/tookscan/order/repository/impl/IssuedCouponRepositoryImpl.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/impl/IssuedCouponRepositoryImpl.java
@@ -25,8 +25,8 @@ public class IssuedCouponRepositoryImpl implements IssuedCouponRepository {
     }
 
     @Override
-    public IssuedCoupon findByCodeOrElseThrow(String couponCode) {
-        return issuedCouponJpaRepository.findByCode(couponCode)
+    public IssuedCoupon findWithCouponTemplateByCodeOrElseThrow(String couponCode) {
+        return issuedCouponJpaRepository.findWithCouponTemplateByCode(couponCode)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_ISSUED_COUPON, "쿠폰 코드: " + couponCode));
     }
 

--- a/src/main/java/com/tookscan/tookscan/order/repository/mysql/IssuedCouponJpaRepository.java
+++ b/src/main/java/com/tookscan/tookscan/order/repository/mysql/IssuedCouponJpaRepository.java
@@ -11,13 +11,14 @@ import java.util.Optional;
 
 public interface IssuedCouponJpaRepository extends JpaRepository<IssuedCoupon, Long> {
 
-    Optional<IssuedCoupon> findByCode(String couponCode);
-
     @EntityGraph(attributePaths = {"usedCoupons"})
     Page<IssuedCoupon> findByCouponTemplateId(Long couponTemplateId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"usedCoupons"})
     List<IssuedCoupon> findByCouponTemplateId(Long couponTemplateId);
+
+    @EntityGraph(attributePaths = {"couponTemplate"})
+    Optional<IssuedCoupon> findWithCouponTemplateByCode(String couponCode);
 
     boolean existsByCode(String couponCode);
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #786 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 유저 쿠폰 상세 조회에 유효기간 및 description 필드 추가 

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 쿠폰 조회 API 추가: 쿠폰 코드로 사용자 주문 쿠폰 상세를 확인할 수 있습니다.
  - 쿠폰 상세 응답에 유효기간 정보(start_date, end_date)와 유형별 가독성 높은 설명이 포함됩니다.

- 문서
  - 회원가입 예시에서 birth 값 형식을 정리했습니다.
  - 휴대폰 인증번호 예시 값을 업데이트했습니다.
  - 게스트 주문 상세 엔드포인트 표기를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->