### PR TITLE
🔨 Fix - 관리자 주문 상세에 쿠폰id 추가

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminOrderDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminOrderDetailResponseDto.java
@@ -568,6 +568,9 @@ public class ReadAdminOrderDetailResponseDto extends
             @NotNull
             private final Integer deliveryPrice;
 
+            @JsonProperty("coupon_id")
+            private final Long couponId;
+
             @JsonProperty("coupon_name")
             private final String couponName;
 
@@ -581,13 +584,14 @@ public class ReadAdminOrderDetailResponseDto extends
 
             @Builder
             public PaymentInfoDto(Integer documentsPrice, Integer cuttingPrice, Boolean isOneDayScan,
-                                  Integer oneDayScanPrice, Integer deliveryPrice, Integer couponDiscount,
+                                  Integer oneDayScanPrice, Integer deliveryPrice, Long couponId, Integer couponDiscount,
                                   Integer totalPrice, String couponName) {
                 this.documentsPrice = documentsPrice;
                 this.cuttingPrice = cuttingPrice;
                 this.isOneDayScan = isOneDayScan;
                 this.oneDayScanPrice = oneDayScanPrice;
                 this.deliveryPrice = deliveryPrice;
+                this.couponId = couponId;
                 this.couponDiscount = couponDiscount;
                 this.couponName = couponName;
                 this.totalPrice = totalPrice;
@@ -607,6 +611,7 @@ public class ReadAdminOrderDetailResponseDto extends
                                 .map(Document::getOneDayScanPrice)
                                 .reduce(0, Integer::sum))
                         .deliveryPrice(order.getDelivery().getDeliveryPrice())
+                        .couponId(order.getUsedCoupon() != null ? order.getUsedCoupon().getId() : null)
                         .couponName(order.getUsedCoupon() != null ? order.getUsedCoupon().getIssuedCoupon().getCouponTemplate().getName() : null)
                         .couponDiscount(order.getUsedCoupon() != null ?
                                 order.getUsedCoupon().getIssuedCoupon().getDiscountPrice(order.getDocumentsTotalAmount(), order.getDocuments().stream().mapToInt(Document::getOcrPrice).sum(), order.getDelivery().getDeliveryPrice()) : 0)


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #797 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 관리자 주문 상세에 쿠폰id 추가

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 관리자 주문 상세의 결제 정보에 사용된 쿠폰 ID가 추가로 표시됩니다. 주문별 쿠폰 사용 내역을 한눈에 확인할 수 있으며, 쿠폰 단위로 분류·집계가 용이해집니다. 쿠폰이 사용된 주문에만 값이 노출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->