### PR TITLE
🔨 Fix - IssuedCoupon이 아닌 UsedCoupon의 id를 넘기고있던 버그 수정

### DIFF
--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminOrderDetailResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminOrderDetailResponseDto.java
@@ -569,7 +569,7 @@ public class ReadAdminOrderDetailResponseDto extends
             private final Integer deliveryPrice;
 
             @JsonProperty("coupon_id")
-            private final Long couponId;
+            private final String couponId;
 
             @JsonProperty("coupon_name")
             private final String couponName;
@@ -584,7 +584,7 @@ public class ReadAdminOrderDetailResponseDto extends
 
             @Builder
             public PaymentInfoDto(Integer documentsPrice, Integer cuttingPrice, Boolean isOneDayScan,
-                                  Integer oneDayScanPrice, Integer deliveryPrice, Long couponId, Integer couponDiscount,
+                                  Integer oneDayScanPrice, Integer deliveryPrice, String couponId, Integer couponDiscount,
                                   Integer totalPrice, String couponName) {
                 this.documentsPrice = documentsPrice;
                 this.cuttingPrice = cuttingPrice;
@@ -611,7 +611,7 @@ public class ReadAdminOrderDetailResponseDto extends
                                 .map(Document::getOneDayScanPrice)
                                 .reduce(0, Integer::sum))
                         .deliveryPrice(order.getDelivery().getDeliveryPrice())
-                        .couponId(order.getUsedCoupon() != null ? order.getUsedCoupon().getId() : null)
+                        .couponId(order.getUsedCoupon() != null ? order.getUsedCoupon().getIssuedCoupon().getId().toString() : null)
                         .couponName(order.getUsedCoupon() != null ? order.getUsedCoupon().getIssuedCoupon().getCouponTemplate().getName() : null)
                         .couponDiscount(order.getUsedCoupon() != null ?
                                 order.getUsedCoupon().getIssuedCoupon().getDiscountPrice(order.getDocumentsTotalAmount(), order.getDocuments().stream().mapToInt(Document::getOcrPrice).sum(), order.getDelivery().getDeliveryPrice()) : 0)


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #799 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- IssuedCoupon이 아닌 UsedCoupon의 id를 넘기고있던 버그 수정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 사항 없음
- 버그 수정
  - 관리자 주문 상세에서 쿠폰 식별자가 잘못 표기되던 문제를 수정하여 실제 “발급 쿠폰” ID가 표시됩니다.
- 문서
  - 응답의 쿠폰 ID 형식이 숫자에서 문자열로 변경됩니다. API 연동 시 문자열 처리로 업데이트해 주세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->