### PR TITLE
🔨 Fix - PDF 업로드 presigned url 처리

### DIFF
--- a/src/main/java/com/tookscan/tookscan/core/config/AwsConfig.java
+++ b/src/main/java/com/tookscan/tookscan/core/config/AwsConfig.java
@@ -3,10 +3,12 @@ package com.tookscan.tookscan.core.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 @Configuration
@@ -51,6 +53,17 @@ public class AwsConfig {
     public S3TransferManager s3TransferManager(S3AsyncClient s3AsyncClient) {
         return S3TransferManager.builder()
                 .s3Client(s3AsyncClient)
+                .build();
+    }
+
+    /**
+     * S3 Presigner Bean 설정 (프리사인드 URL 생성용)
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .credentialsProvider((AwsCredentialsProvider) awsCredentialsProvider())
+                .region(Region.of(region))
                 .build();
     }
 }

--- a/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
+++ b/src/main/java/com/tookscan/tookscan/core/utility/S3Util.java
@@ -7,12 +7,17 @@ import com.tookscan.tookscan.order.domain.Pdf;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +27,11 @@ import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
@@ -35,6 +44,7 @@ public class S3Util {
     private final S3Client s3Client;
     private final CloudFrontUtilities cloudFrontUtilities;
     private final S3TransferManager s3TransferManager;
+    private final S3Presigner s3Presigner;
 
     private final String pdfContentPrefix;
     private final String bucketName;
@@ -48,6 +58,7 @@ public class S3Util {
     public S3Util(
             S3Client s3Client,
             S3TransferManager s3TransferManager,
+            S3Presigner s3Presigner,
             @Value("${spring.cloud.aws.s3.pdf.prefix}") String pdfContentPrefix,
             @Value("${spring.cloud.aws.s3.bucket}") String bucketName,
             @Value("${spring.cloud.aws.cloudfront.domain}") String cloudFrontDomain,
@@ -55,12 +66,57 @@ public class S3Util {
             @Value("${spring.cloud.aws.cloudfront.private-key-path}") Resource privateKeyResource) {
         this.s3Client = s3Client;
         this.s3TransferManager = s3TransferManager;
+        this.s3Presigner = s3Presigner;
         this.pdfContentPrefix = pdfContentPrefix;
         this.bucketName = bucketName;
         this.cloudFrontDomain = cloudFrontDomain;
         this.cloudFrontKeyPairId = cloudFrontKeyPairId;
         this.privateKeyResource = privateKeyResource;
         this.cloudFrontUtilities = CloudFrontUtilities.create();
+    }
+
+    /**
+     * PDF 업로드용 Presigned PUT URL 생성 및 필수 헤더 반환
+     */
+    public PresignedUpload getPresignedPutUrlForPdf(Document document,
+                                                    String storedFileName,
+                                                    String originalFileName,
+                                                    Duration signatureDuration) {
+        String s3Key = buildPdfS3Key(document, storedFileName);
+
+        String contentDisposition = "inline; filename*=UTF-8''" +
+                URLEncoder.encode(originalFileName, java.nio.charset.StandardCharsets.UTF_8);
+
+        PutObjectRequest putRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .contentType("application/pdf")
+                .contentDisposition(contentDisposition)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(signatureDuration)
+                .putObjectRequest(putRequest)
+                .build();
+
+        PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/pdf");
+        headers.put("Content-Disposition", contentDisposition);
+
+        return new PresignedUpload(presigned.url().toExternalForm(), headers);
+    }
+
+    @Getter
+    public static class PresignedUpload {
+        private final String url;
+        private final Map<String, String> headers;
+
+        public PresignedUpload(String url, Map<String, String> headers) {
+            this.url = url;
+            this.headers = headers;
+        }
     }
 
     /**

--- a/src/main/java/com/tookscan/tookscan/order/application/service/ReadAdminPdfUploadStatusService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/ReadAdminPdfUploadStatusService.java
@@ -1,0 +1,23 @@
+package com.tookscan.tookscan.order.application.service;
+
+import com.tookscan.tookscan.order.application.usecase.ReadAdminPdfUploadStatusUseCase;
+import com.tookscan.tookscan.order.domain.Pdf;
+import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminPdfUploadStatusResponseDto;
+import com.tookscan.tookscan.order.repository.PdfRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReadAdminPdfUploadStatusService implements ReadAdminPdfUploadStatusUseCase {
+
+    private final PdfRepository pdfRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReadAdminPdfUploadStatusResponseDto execute(Long pdfId) {
+        Pdf pdf = pdfRepository.findByIdOrElseThrow(pdfId);
+        return ReadAdminPdfUploadStatusResponseDto.fromEntity(pdf);
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/service/UploadAdminDocumentsPdfWithPresignedUrlService.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/service/UploadAdminDocumentsPdfWithPresignedUrlService.java
@@ -1,0 +1,106 @@
+package com.tookscan.tookscan.order.application.service;
+
+import com.tookscan.tookscan.core.annotation.BusinessLog;
+import com.tookscan.tookscan.core.exception.error.ErrorCode;
+import com.tookscan.tookscan.core.exception.type.CommonException;
+import com.tookscan.tookscan.core.utility.S3Util;
+import com.tookscan.tookscan.order.application.usecase.UploadAdminDocumentsPdfWithPresignedUrlUseCase;
+import com.tookscan.tookscan.order.domain.Document;
+import com.tookscan.tookscan.order.domain.Pdf;
+import com.tookscan.tookscan.order.domain.service.PdfService;
+import com.tookscan.tookscan.order.domain.type.EPdfUploadStatus;
+import com.tookscan.tookscan.order.presentation.dto.request.UploadAdminDocumentsPdfWithPresignedUrlRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.response.UploadAdminDocumentsPdfWithPresignedUrlResponseDto;
+import com.tookscan.tookscan.order.repository.DocumentRepository;
+import com.tookscan.tookscan.order.repository.PdfRepository;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UploadAdminDocumentsPdfWithPresignedUrlService implements UploadAdminDocumentsPdfWithPresignedUrlUseCase {
+
+    private final PdfRepository pdfRepository;
+    private final DocumentRepository documentRepository;
+    private final PdfService pdfService;
+    private final S3Util s3Util;
+    private final static Integer PRESIGNED_URL_EXPIRATION_MINUTES = 15;
+
+    @Override
+    @Transactional
+    @BusinessLog(
+            domain = "Order",
+            action = "upload pdfs with presigned urls",
+            userType = "ADMIN"
+    )
+    public UploadAdminDocumentsPdfWithPresignedUrlResponseDto execute(Long documentId,
+                                                                      UploadAdminDocumentsPdfWithPresignedUrlRequestDto requestDto) {
+        Document document = documentRepository.findByIdOrElseThrow(documentId);
+
+        // 요청 파일명 중복 검증 및 기존 파일명과의 중복 검증
+        Set<String> uniqueNames = new HashSet<>();
+        for (String name : requestDto.fileNames()) {
+            if (name == null || name.isBlank()) {
+                throw new CommonException(ErrorCode.INVALID_ARGUMENT, "파일명이 비어있습니다.");
+            }
+            if (!uniqueNames.add(name)) {
+                throw new CommonException(ErrorCode.DUPLICATE_PDF_FILENAME, "중복된 파일명이 감지되었습니다: " + name);
+            }
+        }
+        pdfService.validateUniqueFilenames(document, uniqueNames);
+
+        List<Pdf> toSave = new ArrayList<>();
+        List<S3Util.PresignedUpload> presignedUploads = new ArrayList<>();
+        List<String> fileNames = new ArrayList<>();
+
+        for (String originalFileName : requestDto.fileNames()) {
+
+            String storedFileName = UUID.randomUUID() + ".pdf";
+
+            Pdf preCreated = Pdf.builder()
+                    .name(originalFileName)
+                    .storedFileName(storedFileName)
+                    .isChecked(false)
+                    .document(document)
+                    .uploadStatus(EPdfUploadStatus.IN_PROGRESS)
+                    .build();
+            toSave.add(preCreated);
+
+            S3Util.PresignedUpload presigned = s3Util.getPresignedPutUrlForPdf(
+                    document,
+                    storedFileName,
+                    originalFileName,
+                    Duration.ofMinutes(PRESIGNED_URL_EXPIRATION_MINUTES)
+            );
+            presignedUploads.add(presigned);
+            fileNames.add(originalFileName);
+        }
+
+        // PDF 저장
+        pdfRepository.saveAll(toSave);
+
+        // 저장된 PDF ID와 함께 UploadInfo 생성
+        List<UploadAdminDocumentsPdfWithPresignedUrlResponseDto.UploadInfo> uploads = new ArrayList<>();
+        for (int i = 0; i < toSave.size(); i++) {
+            uploads.add(UploadAdminDocumentsPdfWithPresignedUrlResponseDto.UploadInfo.builder()
+                    .pdfId(toSave.get(i).getId().toString())
+                    .fileName(fileNames.get(i))
+                    .url(presignedUploads.get(i).getUrl())
+                    .headers(presignedUploads.get(i).getHeaders())
+                    .build());
+        }
+
+        return UploadAdminDocumentsPdfWithPresignedUrlResponseDto.builder()
+                .uploads(uploads)
+                .build();
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/usecase/ReadAdminPdfUploadStatusUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/usecase/ReadAdminPdfUploadStatusUseCase.java
@@ -1,0 +1,10 @@
+package com.tookscan.tookscan.order.application.usecase;
+
+
+import com.tookscan.tookscan.core.annotation.bean.UseCase;
+import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminPdfUploadStatusResponseDto;
+
+@UseCase
+public interface ReadAdminPdfUploadStatusUseCase {
+    ReadAdminPdfUploadStatusResponseDto execute(Long pdfId);
+}

--- a/src/main/java/com/tookscan/tookscan/order/application/usecase/UploadAdminDocumentsPdfWithPresignedUrlUseCase.java
+++ b/src/main/java/com/tookscan/tookscan/order/application/usecase/UploadAdminDocumentsPdfWithPresignedUrlUseCase.java
@@ -1,0 +1,11 @@
+package com.tookscan.tookscan.order.application.usecase;
+
+import com.tookscan.tookscan.core.annotation.bean.UseCase;
+import com.tookscan.tookscan.order.presentation.dto.request.UploadAdminDocumentsPdfWithPresignedUrlRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.response.UploadAdminDocumentsPdfWithPresignedUrlResponseDto;
+
+@UseCase
+public interface UploadAdminDocumentsPdfWithPresignedUrlUseCase {
+    UploadAdminDocumentsPdfWithPresignedUrlResponseDto execute(Long documentId,
+                                                               UploadAdminDocumentsPdfWithPresignedUrlRequestDto requestDto);
+}

--- a/src/main/java/com/tookscan/tookscan/order/domain/type/EPdfUploadStatus.java
+++ b/src/main/java/com/tookscan/tookscan/order/domain/type/EPdfUploadStatus.java
@@ -10,6 +10,7 @@ public enum EPdfUploadStatus {
     FAILED("실패"),
     PENDING("대기 중"),
     IN_PROGRESS("진행 중"),
+    WATERMARKING("워터마킹 중")
     ;
 
     private final String description;
@@ -20,6 +21,7 @@ public enum EPdfUploadStatus {
             case "FAILED" -> FAILED;
             case "PENDING" -> PENDING;
             case "IN_PROGRESS" -> IN_PROGRESS;
+            case "WATERMARKING" -> WATERMARKING;
             default -> throw new IllegalArgumentException("Invalid PDF upload status: " + value);
         };
     }

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/command/OrderAdminCommandV1Controller.java
@@ -25,6 +25,7 @@ import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrdersStatusCo
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrdersStatusRecoveryOptionUseCase;
 import com.tookscan.tookscan.order.application.usecase.UpdateAdminOrdersStatusUseCase;
 import com.tookscan.tookscan.order.application.usecase.UploadAdminDocumentsPdfUseCase;
+import com.tookscan.tookscan.order.application.usecase.UploadAdminDocumentsPdfWithPresignedUrlUseCase;
 import com.tookscan.tookscan.order.application.usecase.ValidateAdminPdfUseCase;
 import com.tookscan.tookscan.order.presentation.dto.request.CreateAdminOrderCouponRequestDto;
 import com.tookscan.tookscan.order.presentation.dto.request.CreateAdminOrderMemoRequestDto;
@@ -37,7 +38,9 @@ import com.tookscan.tookscan.order.presentation.dto.request.UpdateAdminOrdersSta
 import com.tookscan.tookscan.order.presentation.dto.request.UpdateAdminOrdersStatusCompanyArrivedRequestDto;
 import com.tookscan.tookscan.order.presentation.dto.request.UpdateAdminOrdersStatusRecoveryOptionRequestDto;
 import com.tookscan.tookscan.order.presentation.dto.request.UpdateAdminOrdersStatusRequestDto;
+import com.tookscan.tookscan.order.presentation.dto.request.UploadAdminDocumentsPdfWithPresignedUrlRequestDto;
 import com.tookscan.tookscan.order.presentation.dto.response.UploadAdminDocumentsPdfResponseDto;
+import com.tookscan.tookscan.order.presentation.dto.response.UploadAdminDocumentsPdfWithPresignedUrlResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ValidateAdminPdfResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -91,6 +94,7 @@ public class OrderAdminCommandV1Controller {
     private final DeleteAdminCouponTemplateUseCase deleteAdminCouponTemplateUseCase;
     private final ExportAdminIssuedCouponExcelUseCase exportAdminIssuedCouponExcelUseCase;
     private final ExportAdminUsedCouponExcelUseCase exportAdminUsedCouponExcelUseCase;
+    private final UploadAdminDocumentsPdfWithPresignedUrlUseCase uploadAdminDocumentsPdfWithPresignedUrlUseCase;
 
     /**
      * 4.1.3 관리자 배송 리스트 내보내기
@@ -162,7 +166,7 @@ public class OrderAdminCommandV1Controller {
             ErrorCode.UPLOAD_FILE_ERROR,
             ErrorCode.ACCESS_DENIED
     })
-    @PostMapping(value = "/documents/{documentId}/pdfs", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/documents/{documentId}/pdfs/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<UploadAdminDocumentsPdfResponseDto> uploadPdf(
             @PathVariable Long documentId,
             @RequestPart("files") List<MultipartFile> files
@@ -170,6 +174,20 @@ public class OrderAdminCommandV1Controller {
         return ResponseDto.ok(uploadAdminDocumentsPdfUseCase.execute(documentId, files));
     }
 
+    /**
+     * 4.1.6(수정) 관리자 pdf 파일 업로드 Presign URL 방식
+     */
+    @Operation(summary = "관리자 pdf 파일 업로드", description = "관리자가 pdf 파일을 업로드합니다. 단일 파일 또는 다중 파일 업로드를 지원합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_DOCUMENT
+    })
+    @PostMapping(value = "/documents/{documentId}/pdfs")
+    public ResponseDto<UploadAdminDocumentsPdfWithPresignedUrlResponseDto> getUploadPdfPresignUrls(
+            @PathVariable Long documentId,
+            @RequestBody @Valid UploadAdminDocumentsPdfWithPresignedUrlRequestDto requestDto
+    ) {
+        return ResponseDto.ok(uploadAdminDocumentsPdfWithPresignedUrlUseCase.execute(documentId, requestDto));
+    }
     /**
      * 4.3.2 관리자 주문 상태 일괄 변경
      */

--- a/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/controller/query/OrderAdminQueryV1Controller.java
@@ -10,6 +10,7 @@ import com.tookscan.tookscan.order.application.usecase.ReadAdminIssuedCouponOver
 import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderBriefsUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderDetailUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminOrderOverviewsUseCase;
+import com.tookscan.tookscan.order.application.usecase.ReadAdminPdfUploadStatusUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadAdminUsedCouponOverviewUseCase;
 import com.tookscan.tookscan.order.application.usecase.ReadStatisticsSummariesUseCase;
 import com.tookscan.tookscan.order.application.usecase.SubscribePdfProgressUseCase;
@@ -23,6 +24,7 @@ import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminIssuedCoup
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderBriefsResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderDetailResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminOrderOverviewsResponseDto;
+import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminPdfUploadStatusResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadAdminUsedCouponOverviewResponseDto;
 import com.tookscan.tookscan.order.presentation.dto.response.ReadStatisticsSummariesResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,6 +54,7 @@ public class OrderAdminQueryV1Controller {
     private final ReadAdminOrderOverviewsUseCase readAdminOrderOverviewsUseCase;
     private final ReadStatisticsSummariesUseCase readStatisticsSummariesUseCase;
     private final ReadAdminDocumentsPdfsUseCase readAdminDocumentsPdfsUseCase;
+    private final ReadAdminPdfUploadStatusUseCase readAdminPdfUploadStatusUseCase;
     private final ReadAdminCouponTemplateOverviewUseCase readAdminCouponTemplateOverviewUseCase;
     private final ReadAdminIssuedCouponOverviewUseCase readAdminIssuedCouponOverviewUseCase;
     private final ReadAdminUsedCouponOverviewUseCase readAdminUsedCouponOverviewUseCase;
@@ -216,6 +219,21 @@ public class OrderAdminQueryV1Controller {
             @PathVariable Long id
     ) {
         return ResponseDto.ok(readAdminCouponTemplateDetailUseCase.execute(id));
+    }
+
+    /**
+     * 관리자 PDF 업로드 상태 조회
+     */
+    @Operation(summary = "관리자 PDF 업로드 상태 조회", description = "관리자가 PDF 업로드 상태를 조회합니다.")
+    @ApiErrorCode({
+            ErrorCode.NOT_FOUND_PDF,
+            ErrorCode.ACCESS_DENIED
+    })
+    @GetMapping("/orders/documents/pdfs/{pdfId}/upload-status")
+    public ResponseDto<ReadAdminPdfUploadStatusResponseDto> readPdfUploadStatus(
+            @PathVariable Long pdfId
+    ) {
+        return ResponseDto.ok(readAdminPdfUploadStatusUseCase.execute(pdfId));
     }
 
     @Operation(summary = "관리자용 PDF 업로드 진행 SSE", description = "관리자가 주문/문서 단위 업로드 진행 이벤트를 수신합니다.")

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/UploadAdminDocumentsPdfWithPresignedUrlRequestDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/request/UploadAdminDocumentsPdfWithPresignedUrlRequestDto.java
@@ -1,0 +1,10 @@
+package com.tookscan.tookscan.order.presentation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record UploadAdminDocumentsPdfWithPresignedUrlRequestDto(
+        @JsonProperty("file_names")
+        List<String> fileNames
+) {
+}

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminPdfUploadStatusResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/ReadAdminPdfUploadStatusResponseDto.java
@@ -1,0 +1,44 @@
+package com.tookscan.tookscan.order.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tookscan.tookscan.core.dto.SelfValidating;
+import com.tookscan.tookscan.order.domain.Pdf;
+import com.tookscan.tookscan.order.domain.type.EPdfUploadStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReadAdminPdfUploadStatusResponseDto extends SelfValidating<ReadAdminPdfUploadStatusResponseDto> {
+
+    @JsonProperty("upload_status")
+    private final EPdfUploadStatus uploadStatus;
+
+    @JsonProperty("pdf_url_for_admin")
+    private final String pdfUrlForAdmin;
+
+    @JsonProperty("name")
+    private final String name;
+
+    @Builder
+    public ReadAdminPdfUploadStatusResponseDto(EPdfUploadStatus uploadStatus, String pdfUrlForAdmin, String name) {
+        this.uploadStatus = uploadStatus;
+        this.pdfUrlForAdmin = pdfUrlForAdmin;
+        this.name = name;
+        this.validateSelf();
+    }
+
+    public static ReadAdminPdfUploadStatusResponseDto fromEntity(Pdf pdf) {
+        String pdfUrlForAdmin = null;
+        
+        // Only include pdf_url_for_admin if upload_status is COMPLETED and url exists
+        if (pdf.getUploadStatus() == EPdfUploadStatus.COMPLETED && pdf.getPdfUrlForAdmin() != null) {
+            pdfUrlForAdmin = pdf.getPdfUrlForAdmin();
+        }
+
+        return ReadAdminPdfUploadStatusResponseDto.builder()
+                .uploadStatus(pdf.getUploadStatus())
+                .pdfUrlForAdmin(pdfUrlForAdmin)
+                .name(pdf.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/UploadAdminDocumentsPdfWithPresignedUrlResponseDto.java
+++ b/src/main/java/com/tookscan/tookscan/order/presentation/dto/response/UploadAdminDocumentsPdfWithPresignedUrlResponseDto.java
@@ -1,0 +1,45 @@
+package com.tookscan.tookscan.order.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tookscan.tookscan.core.dto.SelfValidating;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UploadAdminDocumentsPdfWithPresignedUrlResponseDto extends
+        SelfValidating<UploadAdminDocumentsPdfWithPresignedUrlResponseDto> {
+    @JsonProperty("uploads")
+    private final List<UploadInfo> uploads;
+
+    @Builder
+    public UploadAdminDocumentsPdfWithPresignedUrlResponseDto(List<UploadInfo> uploads) {
+        this.uploads = uploads;
+        this.validateSelf();
+    }
+
+    @Getter
+    public static class UploadInfo extends SelfValidating<UploadInfo> {
+        @JsonProperty("pdf_id")
+        private String pdfId;
+
+        @JsonProperty("file_name")
+        private final String fileName;
+
+        @JsonProperty("url")
+        private final String url;
+
+        @JsonProperty("headers")
+        private final Map<String, String> headers;
+
+        @Builder
+        public UploadInfo(String pdfId, String fileName, String url, Map<String, String> headers) {
+            this.pdfId = pdfId;
+            this.fileName = fileName;
+            this.url = url;
+            this.headers = headers;
+            this.validateSelf();
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
closed #796

어떤 변경사항이 있었나요?
- [x] 🔨 Fix: Feature change or bug fix

## CheckPoint ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
관리자가 PDF 파일을 업로드할 때 presigned url을 사용하여 클라이언트에서 직접 S3에 업로드할 수 있도록 수정했습니다.

### 주요 변경사항
- **새로운 API 추가**: `/v1/admins/orders/{orderId}/documents/pdf-presigned-url`
  - 관리자가 PDF 업로드를 위한 presigned url을 요청할 수 있는 엔드포인트 추가
  - 요청: 문서 목록과 업로드할 PDF 정보
  - 응답: S3 presigned url 목록과 업로드 상태 추적을 위한 정보

- **PDF 업로드 상태 조회 API 추가**: `/v1/admins/orders/{orderId}/pdf-upload-status`
  - 관리자가 PDF 업로드 진행 상태를 실시간으로 확인할 수 있는 조회 API
  - EPdfUploadStatus enum을 통한 상태 관리 (IN_PROGRESS, WATERMARKING, COMPLETED, FAILED)

- **도메인 모델 개선**:
  - DocumentService와 PdfService에서 presigned url 생성 및 관리 로직 구현

- **S3 유틸리티 개선**:
  - S3Util에 presigned url 생성 기능 추가
  - AWS 설정 최적화 및 보안 강화

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- presigned url 생성 시 보안 정책이 올바르게 적용되었는지 확인해주세요
- PDF 업로드 상태 추적 로직이 예상대로 동작하는지 검토해주세요
- S3 권한 설정이 적절한지 확인해주세요